### PR TITLE
geotargets options / defaults update

### DIFF
--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -7,4 +7,7 @@ geotargets_env <- function() {
 .onAttach <- function(lib, pkg) {
     geotargets.env$geotargets.gdal.raster.creation_options <- geotargets_option_get("gdal.raster.creation_options")
     geotargets.env$geotargets.gdal.raster.driver <- geotargets_option_get("gdal.raster.driver")
+
+    geotargets.env$geotargets.gdal.vector.creation_options <- geotargets_option_get("gdal.vector.creation_options")
+    geotargets.env$geotargets.gdal.vector.driver <- geotargets_option_get("gdal.vector.driver")
 }

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -6,5 +6,5 @@ geotargets_env <- function() {
 
 .onAttach <- function(lib, pkg) {
     geotargets.env$geotargets.gdal.raster.creation_options <- "ENCODING=UTF-8"
-    geotargets.env$geotargets.gdal.raster.driver_name <- "GTiff"
+    geotargets.env$geotargets.gdal.raster.driver <- "GTiff"
 }

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -5,6 +5,6 @@ geotargets_env <- function() {
 }
 
 .onAttach <- function(lib, pkg) {
-    geotargets.env$geotargets.gdal.raster.creation_options <- "ENCODING=UTF-8"
-    geotargets.env$geotargets.gdal.raster.driver <- "GTiff"
+    geotargets.env$geotargets.gdal.raster.creation_options <- geotargets_option_get("gdal.raster.creation_options")
+    geotargets.env$geotargets.gdal.raster.driver <- geotargets_option_get("gdal.raster.driver")
 }

--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -8,14 +8,22 @@
 #'
 #' ## Available Options
 #'
-#'  - `"geotargets.gdal.raster.creation_options"` - set the GDAL creation options used when writing raster files to target store (default: `"ENCODING=UTF-8"`)
+#'  - `"geotargets.gdal.raster.driver"` - character. Length 1. Set the driver used for raster data in target store (default: `"GTiff"`). Options for driver names can be found here: <https://gdal.org/drivers/raster/index.html>
 #'
-#'  - `"geotargets.gdal.raster.driver"` - set the file type used for raster data in target store (default: `"GTiff"`)
+#'  - `"geotargets.gdal.raster.creation_options"` - character. Set the GDAL creation options used when writing raster files to target store (default: `"ENCODING=UTF-8"`). You may specify multiple values e.g. `c("COMPRESS=DEFLATE", "TFW=YES")`. Each GDAL driver supports a unique set of creation options. For example, with the default `"GTiff"` driver: <https://gdal.org/drivers/raster/gtiff.html#creation-options>
+#'
+#'  - `"geotargets.gdal.vector.driver"` - character. Length 1. Set the file type used for vector data in target store (default: `"GeoJSON"`).
+#'
+#'  - `"geotargets.gdal.vector.creation_options"` - character. Set the GDAL layer creation options used when writing vector files to target store (default: `"ENCODING=UTF-8"`). You may specify multiple values e.g. `c("WRITE_BBOX=YES", "COORDINATE_PRECISION=10")`. Each GDAL driver supports a unique set of creation options. For example, with the default `"GeoJSON"` driver: <https://gdal.org/drivers/vector/geojson.html#layer-creation-options>
 #'
 #'  Each option can be overridden with a system environment variable. Options include:
 #'
-#'   - `GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS`
 #'   - `GEOTARGETS_GDAL_RASTER_DRIVER`
+#'   - `GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS`
+#'   - `GEOTARGETS_GDAL_VECTOR_DRIVER`
+#'   - `GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS`
+#'
+#'  When specifying options that support multiple values using a system environment variable, the separate options should be delimited with a semicolon (";"). For example: `"COMPRESS=DEFLATE;TFW=YES"`.
 #'
 #' @rdname geotargets-options
 #' @export
@@ -46,11 +54,30 @@ geotargets_option_get <- function(option_name) {
         )
     }
 
+    get_geotargets_gdal_vector_creation_options <- function(option_name, option_value) {
+        gdal_creation_options <- Sys.getenv(
+            x = "GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS",
+            unset = get_option(option_name, option_value, "ENCODING=UTF-8")
+        )
+        the_option <- strsplit(gdal_creation_options, ";")[[1]]
+        the_option
+    }
+
+    get_geotargets_gdal_vector_driver <- function(option_name, option_value) {
+        Sys.getenv(
+            x = "GEOTARGETS_GDAL_VECTOR_DRIVER",
+            unset = get_option(option_name, option_value, "GeoJSON")
+        )
+    }
     switch(option_name,
            "geotargets.gdal.raster.creation_options" =
                get_geotargets_gdal_raster_creation_options(option_name, option_value),
            "geotargets.gdal.raster.driver" =
-               get_geotargets_gdal_raster_driver(option_name, option_value)
+               get_geotargets_gdal_raster_driver(option_name, option_value),
+           "geotargets.gdal.vector.creation_options" =
+               get_geotargets_gdal_vector_creation_options(option_name, option_value),
+           "geotargets.gdal.vector.driver" =
+               get_geotargets_gdal_vector_driver(option_name, option_value)
     )
 }
 

--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -28,10 +28,8 @@
 #' @rdname geotargets-options
 #' @export
 geotargets_option_get <- function(option_name) {
-    if (!startsWith(option_name, "geotargets.")) {
-        option_name <- paste0("geotargets.", option_name)
-    }
 
+    option_name <- geotargets_repair_option_name(option_name)
     option_value <- geotargets_env()[[option_name]]
 
     get_option <- function(option_name, option_value, name){
@@ -69,6 +67,7 @@ geotargets_option_get <- function(option_name) {
             unset = get_option(option_name, option_value, "GeoJSON")
         )
     }
+
     switch(option_name,
            "geotargets.gdal.raster.creation_options" =
                get_geotargets_gdal_raster_creation_options(option_name, option_value),
@@ -85,8 +84,12 @@ geotargets_option_get <- function(option_name) {
 #' @rdname geotargets-options
 #' @export
 geotargets_option_set <- function(option_name, option_value) {
+    option_name <- geotargets_repair_option_name(option_name)
+    geotargets.env[[option_name]] <- option_value
+}
+
+geotargets_repair_option_name <- function(option_name) {
     if (!startsWith(option_name, "geotargets.")) {
         option_name <- paste0("geotargets.", option_name)
     }
-    geotargets.env[[option_name]] <- option_value
 }

--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -10,12 +10,12 @@
 #'
 #'  - `"geotargets.gdal.raster.creation_options"` - set the GDAL creation options used when writing raster files to target store (default: `"ENCODING=UTF-8"`)
 #'
-#'  - `"geotargets.gdal.raster.driver_name"` - set the file type used for raster data in target store (default: `"GTiff"`)
+#'  - `"geotargets.gdal.raster.driver"` - set the file type used for raster data in target store (default: `"GTiff"`)
 #'
 #'  Each option can be overridden with a system environment variable. Options include:
 #'
 #'   - `GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS`
-#'   - `GEOTARGETS_GDAL_RASTER_DRIVER_NAME`
+#'   - `GEOTARGETS_GDAL_RASTER_DRIVER`
 #'
 #' @rdname geotargets-options
 #' @export
@@ -39,9 +39,9 @@ geotargets_option_get <- function(option_name) {
         the_option
     }
 
-    get_geotargets_gdal_raster_driver_name <- function(option_name, option_value) {
+    get_geotargets_gdal_raster_driver <- function(option_name, option_value) {
         Sys.getenv(
-            x = "GEOTARGETS_GDAL_RASTER_DRIVER_NAME",
+            x = "GEOTARGETS_GDAL_RASTER_DRIVER",
             unset = get_option(option_name, option_value, "GTiff")
         )
     }
@@ -49,8 +49,8 @@ geotargets_option_get <- function(option_name) {
     switch(option_name,
            "geotargets.gdal.raster.creation_options" =
                get_geotargets_gdal_raster_creation_options(option_name, option_value),
-           "geotargets.gdal.raster.driver_name" =
-               get_geotargets_gdal_raster_driver_name(option_name, option_value)
+           "geotargets.gdal.raster.driver" =
+               get_geotargets_gdal_raster_driver(option_name, option_value)
     )
 }
 

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -64,8 +64,8 @@ tar_terra_rast <- function(name,
     )
 
     # if not specified by user, pull the corresponding geotargets option
-    filetype <- filetype %||% geotargets_option_get("raster.gdal_driver")
-    gdal <- gdal %||% geotargets_option_get("raster.gdal_creation_options")
+    filetype <- filetype %||% geotargets_option_get("gdal.raster.driver")
+    gdal <- gdal %||% geotargets_option_get("gdal.raster.creation_options")
 
     targets::tar_target_raw(
         name = name,

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -64,7 +64,7 @@ tar_terra_rast <- function(name,
     )
 
     # if not specified by user, pull the corresponding geotargets option
-    filetype <- filetype %||% geotargets_option_get("raster.gdal_driver_name")
+    filetype <- filetype %||% geotargets_option_get("raster.gdal_driver")
     gdal <- gdal %||% geotargets_option_get("raster.gdal_creation_options")
 
     targets::tar_target_raw(
@@ -102,7 +102,7 @@ create_format_terra_raster <- function(filetype, gdal, ...) {
     drv <- terra::gdal(drivers = TRUE)
     drv <- drv[drv$type == "raster" & grepl("write", drv$can), ]
 
-    filetype <- filetype %||% geotargets_option_get("gdal.raster.driver_name")
+    filetype <- filetype %||% geotargets_option_get("gdal.raster.driver")
     filetype <- rlang::arg_match0(filetype, drv$name)
 
     gdal <- gdal %||% geotargets_option_get("gdal.raster.creation_options")
@@ -114,7 +114,7 @@ create_format_terra_raster <- function(filetype, gdal, ...) {
         terra::writeRaster(
             object,
             path,
-            filetype = geotargets::geotargets_option_get("gdal.raster.driver_name"),
+            filetype = geotargets::geotargets_option_get("gdal.raster.driver"),
             overwrite = TRUE,
             gdal = geotargets::geotargets_option_get("gdal.raster.creation_options")
         )

--- a/man/geotargets-options.Rd
+++ b/man/geotargets-options.Rd
@@ -20,14 +20,20 @@ Get or set behavior for geospatial data target stores using geotargets-specific 
 \details{
 \subsection{Available Options}{
 \itemize{
-\item \code{"geotargets.gdal.raster.creation_options"} - set the GDAL creation options used when writing raster files to target store (default: \code{"ENCODING=UTF-8"})
-\item \code{"geotargets.gdal.raster.driver"} - set the file type used for raster data in target store (default: \code{"GTiff"})
+\item \code{"geotargets.gdal.raster.driver"} - character. Length 1. Set the driver used for raster data in target store (default: \code{"GTiff"}). Options for driver names can be found here: \url{https://gdal.org/drivers/raster/index.html}
+\item \code{"geotargets.gdal.raster.creation_options"} - character. Set the GDAL creation options used when writing raster files to target store (default: \code{"ENCODING=UTF-8"}). You may specify multiple values e.g. \code{c("COMPRESS=DEFLATE", "TFW=YES")}. Each GDAL driver supports a unique set of creation options. For example, with the default \code{"GTiff"} driver: \url{https://gdal.org/drivers/raster/gtiff.html#creation-options}
+\item \code{"geotargets.gdal.vector.driver"} - character. Length 1. Set the file type used for vector data in target store (default: \code{"GeoJSON"}).
+\item \code{"geotargets.gdal.vector.creation_options"} - character. Set the GDAL layer creation options used when writing vector files to target store (default: \code{"ENCODING=UTF-8"}). You may specify multiple values e.g. \code{c("WRITE_BBOX=YES", "COORDINATE_PRECISION=10")}. Each GDAL driver supports a unique set of creation options. For example, with the default \code{"GeoJSON"} driver: \url{https://gdal.org/drivers/vector/geojson.html#layer-creation-options}
 }
 
 Each option can be overridden with a system environment variable. Options include:
 \itemize{
-\item \code{GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS}
 \item \code{GEOTARGETS_GDAL_RASTER_DRIVER}
+\item \code{GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS}
+\item \code{GEOTARGETS_GDAL_VECTOR_DRIVER}
+\item \code{GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS}
 }
+
+When specifying options that support multiple values using a system environment variable, the separate options should be delimited with a semicolon (";"). For example: \code{"COMPRESS=DEFLATE;TFW=YES"}.
 }
 }

--- a/man/geotargets-options.Rd
+++ b/man/geotargets-options.Rd
@@ -21,13 +21,13 @@ Get or set behavior for geospatial data target stores using geotargets-specific 
 \subsection{Available Options}{
 \itemize{
 \item \code{"geotargets.gdal.raster.creation_options"} - set the GDAL creation options used when writing raster files to target store (default: \code{"ENCODING=UTF-8"})
-\item \code{"geotargets.gdal.raster.driver_name"} - set the file type used for raster data in target store (default: \code{"GTiff"})
+\item \code{"geotargets.gdal.raster.driver"} - set the file type used for raster data in target store (default: \code{"GTiff"})
 }
 
 Each option can be overridden with a system environment variable. Options include:
 \itemize{
 \item \code{GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS}
-\item \code{GEOTARGETS_GDAL_RASTER_DRIVER_NAME}
+\item \code{GEOTARGETS_GDAL_RASTER_DRIVER}
 }
 }
 }


### PR DESCRIPTION
Some updates to options following #19 for #26 

 - Adds vector data analogs for options introduced in #19, can be used for #21
 - Updates "driver name" options to remove _NAME/_name suffix for #25
 - Other cleanup: fix some option names not updated in #19, and only specify default arguments once (in `geotargets_option_get()`