### PR TITLE
Temporary coverage fix for #31

### DIFF
--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -87,9 +87,3 @@ geotargets_option_set <- function(option_name, option_value) {
     option_name <- geotargets_repair_option_name(option_name)
     geotargets.env[[option_name]] <- option_value
 }
-
-geotargets_repair_option_name <- function(option_name) {
-    if (!startsWith(option_name, "geotargets.")) {
-        option_name <- paste0("geotargets.", option_name)
-    }
-}

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -1,3 +1,38 @@
+# format_terra_vect_shapefile <- targets::tar_format(
+#   read = function(path) {
+#     terra::vect(
+#       paste0(
+#         "/vsizip/",
+#         file.path(
+#           path,
+#           replace_dot_zip_with_shp(path)
+#         )
+#       )
+#     )
+#   },
+#   write = function(object, path) {
+#     terra::writeVector(
+#       x = object,
+#       filename = replace_dot_zip_with_shp(path),
+#       filetype = "ESRI Shapefile",
+#       overwrite = TRUE
+#     )
+#     zf <- list.files(
+#       pattern = replace_dot_zip(
+#         x = path,
+#         replacement = ""
+#       )
+#     )
+#     utils::zip(
+#       zipfile = path,
+#       files = zf
+#     )
+#     unlink(zf)
+#   },
+#   marshal = function(object) terra::wrap(object),
+#   unmarshal = function(object) terra::unwrap(object)
+# )
+
 #' Targets format for terra vectors
 #'
 #' Provides targets format for `terra::vect` objects

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -1,38 +1,3 @@
-# format_terra_vect_shapefile <- targets::tar_format(
-#   read = function(path) {
-#     terra::vect(
-#       paste0(
-#         "/vsizip/",
-#         file.path(
-#           path,
-#           replace_dot_zip_with_shp(path)
-#         )
-#       )
-#     )
-#   },
-#   write = function(object, path) {
-#     terra::writeVector(
-#       x = object,
-#       filename = replace_dot_zip_with_shp(path),
-#       filetype = "ESRI Shapefile",
-#       overwrite = TRUE
-#     )
-#     zf <- list.files(
-#       pattern = replace_dot_zip(
-#         x = path,
-#         replacement = ""
-#       )
-#     )
-#     utils::zip(
-#       zipfile = path,
-#       files = zf
-#     )
-#     unlink(zf)
-#   },
-#   marshal = function(object) terra::wrap(object),
-#   unmarshal = function(object) terra::unwrap(object)
-# )
-
 #' Targets format for terra vectors
 #'
 #' Provides targets format for `terra::vect` objects

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,11 @@
+replace_dot_zip <- function(x, replacement) {
+  gsub(
+    pattern = "\\.zip",
+    replacement = replacement,
+    x = basename(x)
+  )
+}
+
+replace_dot_zip_with_shp <- function(x) {
+  replace_dot_zip(x, ".shp")
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,11 +1,5 @@
-replace_dot_zip <- function(x, replacement) {
-  gsub(
-    pattern = "\\.zip",
-    replacement = replacement,
-    x = basename(x)
-  )
-}
-
-replace_dot_zip_with_shp <- function(x) {
-  replace_dot_zip(x, ".shp")
+geotargets_repair_option_name <- function(option_name) {
+  if (!startsWith(option_name, "geotargets.")) {
+    option_name <- paste0("geotargets.", option_name)
+  }
 }


### PR DESCRIPTION
This seems to get our codecov action working again, for #31, but I am not satisfied with this as a general solution. I do not understand at this time why it would matter if there was code in utils.R or not.

There seems to be some pretty odd stuff that can happen when target tests are being run inside testthat via covr.