### PR TITLE
Moves `terra` to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,9 +33,9 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Imports: 
     rlang,
-    targets,
-    terra
+    targets
 Suggests: 
+    terra,
     testthat (>= 3.0.0)
 Depends:
     R (>= 4.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Language: en-GB
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Imports: 
-    targets
+    targets,
+    rlang
 Suggests: 
     terra,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,43 +2,30 @@ Package: geotargets
 Title: Targets extensions for geospatial formats
 Version: 0.0.0.9000
 Authors@R: c(
-    person(
-      given = "Nicholas", 
-      family = "Tierney", 
-      email = "nicholas.tierney@gmail.com", 
-      role = c("aut", "cre"),
-      comment = c(ORCID = "0000-0003-1460-8722")
-      ),
-    person(
-      given = "Eric",
-      family = "Scott",
-      role = c("aut"),
-      comment = c(ORCID = "0000-0002-7430-7879")
-    ),
-    person(
-      given = "Andrew",
-      family = "Brown",
-      role = c("aut"),
-      comment = c(ORCID = "0000-0002-4565-533X")
-    )
-    )
-Description: Provides extensions for various geospatial file formats, 
-  such as shapefiles and rasters. See the vignettes for worked 
-  examples and demonstrations and explanations of how to use the various
-  package extensions.
+    person("Nicholas", "Tierney", , "nicholas.tierney@gmail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0003-1460-8722")),
+    person("Eric", "Scott", role = "aut",
+           comment = c(ORCID = "0000-0002-7430-7879")),
+    person("Andrew", "Brown", role = "aut",
+           comment = c(ORCID = "0000-0002-4565-533X"))
+  )
+Description: Provides extensions for various geospatial file formats, such
+    as shapefiles and rasters. See the vignettes for worked examples and
+    demonstrations and explanations of how to use the various package
+    extensions.
 License: MIT + file LICENSE
-Encoding: UTF-8
-Language: en-GB
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+URL: https://github.com/njtierney/geotargets
+BugReports: https://github.com/njtierney/geotargets/issues
+Depends:
+    R (>= 4.1.0)
 Imports: 
     rlang,
     targets
 Suggests: 
     terra,
     testthat (>= 3.0.0)
-Depends:
-    R (>= 4.1.0)
 Config/testthat/edition: 3
-URL: https://github.com/njtierney/geotargets
-BugReports: https://github.com/njtierney/geotargets/issues
+Encoding: UTF-8
+Language: en-GB
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,30 +2,34 @@ Package: geotargets
 Title: Targets extensions for geospatial formats
 Version: 0.0.0.9000
 Authors@R: c(
-    person("Nicholas", "Tierney", , "nicholas.tierney@gmail.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0003-1460-8722")),
-    person("Eric", "Scott", role = "aut",
-           comment = c(ORCID = "0000-0002-7430-7879")),
-    person("Andrew", "Brown", role = "aut",
-           comment = c(ORCID = "0000-0002-4565-533X"))
-  )
-Description: Provides extensions for various geospatial file formats, such
-    as shapefiles and rasters. See the vignettes for worked examples and
-    demonstrations and explanations of how to use the various package
-    extensions.
+    person(
+      given = "Nicholas", 
+      family = "Tierney", 
+      email = "nicholas.tierney@gmail.com", 
+      role = c("aut", "cre"),
+      comment = c(ORCID = "0000-0003-1460-8722")
+      ),
+    person(
+      given = "Eric",
+      family = "Scott",
+      role = c("aut"),
+      comment = c(ORCID = "0000-0002-7430-7879")
+    )
+    )
+Description: Provides extensions for various geospatial file formats, 
+  such as shapefiles and rasters. See the vignettes for worked 
+  examples and demonstrations and explanations of how to use the various
+  package extensions.
 License: MIT + file LICENSE
-URL: https://github.com/njtierney/geotargets
-BugReports: https://github.com/njtierney/geotargets/issues
-Depends:
-    R (>= 4.1.0)
+Encoding: UTF-8
+Language: en-GB
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.1
 Imports: 
-    rlang,
     targets
 Suggests: 
     terra,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Encoding: UTF-8
-Language: en-GB
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+URL: https://github.com/njtierney/geotargets
+BugReports: https://github.com/njtierney/geotargets/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Imports: 
     targets,
-    rlang
+    rlang,
+    cli
 Suggests: 
     terra,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,12 @@ Authors@R: c(
       family = "Scott",
       role = c("aut"),
       comment = c(ORCID = "0000-0002-7430-7879")
+    ),
+    person(
+      given = "Andrew",
+      family = "Brown",
+      role = c("aut"),
+      comment = c(ORCID = "0000-0002-4565-533X")
     )
     )
 Description: Provides extensions for various geospatial file formats, 

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -68,8 +68,14 @@ tar_terra_rast <- function(name,
         tidy_eval = tidy_eval
     )
 
+    # get list of drivers available for writing depending on what the user's GDAL supports
+    drv <- terra::gdal(drivers = TRUE)
+    drv <- drv[drv$type == "raster" & grepl("write", drv$can), ]
+
     # if not specified by user, pull the corresponding geotargets option
     filetype <- filetype %||% geotargets_option_get("gdal.raster.driver")
+    filetype <- rlang::arg_match0(filetype, drv$name)
+
     gdal <- gdal %||% geotargets_option_get("gdal.raster.creation_options")
 
     targets::tar_target_raw(
@@ -98,15 +104,6 @@ tar_terra_rast <- function(name,
 #' @param ... Additional arguments not yet used
 #' @noRd
 create_format_terra_raster <- function(filetype, gdal, ...) {
-    # get list of drivers available for writing depending on what the user's GDAL supports
-    drv <- terra::gdal(drivers = TRUE)
-    drv <- drv[drv$type == "raster" & grepl("write", drv$can), ]
-
-    filetype <- filetype %||% geotargets_option_get("gdal.raster.driver")
-    filetype <- rlang::arg_match0(filetype, drv$name)
-
-    gdal <- gdal %||% geotargets_option_get("gdal.raster.creation_options")
-
     # NOTE: Option getting functions are set in the .write_terra_raster function template
     #       to resolve issue with body<- not working in some evaluation contexts ({covr}).
     # TODO: It should be fine to have filetype and gdal as NULL

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -49,7 +49,9 @@ tar_terra_rast <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
 
-    rlang::check_installed("terra")
+    if (!requireNamespace("terra")) {
+        stop("package 'terra' is required", call. = FALSE)
+    }
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -67,9 +67,7 @@ tar_terra_rast <- function(name,
         tidy_eval = tidy_eval
     )
 
-    # get list of drivers available for writing depending on what the user's GDAL supports
-    drv <- terra::gdal(drivers = TRUE)
-    drv <- drv[drv$type == "raster" & grepl("write", drv$can), ]
+    drv <- get_gdal_available_driver_list("raster")
 
     # if not specified by user, pull the corresponding geotargets option
     filetype <- filetype %||% geotargets_option_get("gdal.raster.driver")
@@ -106,9 +104,7 @@ create_format_terra_raster <- function(filetype, gdal, ...) {
 
     check_pkg_installed("terra")
 
-    # get list of drivers available for writing depending on what the user's GDAL supports
-    drv <- terra::gdal(drivers = TRUE)
-    drv <- drv[drv$type == "raster" & grepl("write", drv$can), ]
+    drv <- get_gdal_available_driver_list("raster")
 
     filetype <- filetype %||% geotargets_option_get("gdal.raster.driver")
     filetype <- rlang::arg_match0(filetype, drv$name)

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -49,9 +49,8 @@ tar_terra_rast <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
 
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
+    check_pkg_installed("terra")
+
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")
@@ -105,9 +104,7 @@ tar_terra_rast <- function(name,
 #' @noRd
 create_format_terra_raster <- function(filetype, gdal, ...) {
 
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
+    check_pkg_installed("terra")
 
     # get list of drivers available for writing depending on what the user's GDAL supports
     drv <- terra::gdal(drivers = TRUE)

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -49,6 +49,7 @@ tar_terra_rast <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
 
+    rlang::check_installed("terra")
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")
@@ -95,11 +96,6 @@ tar_terra_rast <- function(name,
 #' @param ... Additional arguments not yet used
 #' @noRd
 create_format_terra_raster <- function(filetype, gdal, ...) {
-
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
-
     # get list of drivers available for writing depending on what the user's GDAL supports
     drv <- terra::gdal(drivers = TRUE)
     drv <- drv[drv$type == "raster" & grepl("write", drv$can), ]

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -57,6 +57,7 @@ tar_terra_vect <- function(name,
                            storage = targets::tar_option_get("storage"),
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
+    rlang::check_installed("terra")
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")
@@ -112,11 +113,6 @@ tar_terra_vect <- function(name,
 #' @param ... Additional arguments not yet used
 #' @noRd
 create_format_terra_vect <- function(filetype, options, ...) {
-
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
-
     # get list of drivers available for writing depending on what the user's GDAL supports
     drv <- terra::gdal(drivers = TRUE)
     drv <- drv[drv$type == "vector" & grepl("write", drv$can), ]
@@ -153,11 +149,6 @@ create_format_terra_vect <- function(filetype, options, ...) {
 #' @param ... Additional arguments not yet used
 #' @noRd
 create_format_terra_vect_shz <- function(options, ...) {
-
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
-
     .write_terra_vector <- function(object, path) {
         terra::writeVector(
             x = object,

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -57,7 +57,9 @@ tar_terra_vect <- function(name,
                            storage = targets::tar_option_get("storage"),
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
-    rlang::check_installed("terra")
+    if (!requireNamespace("terra")) {
+        stop("package 'terra' is required", call. = FALSE)
+    }
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -57,9 +57,9 @@ tar_terra_vect <- function(name,
                            storage = targets::tar_option_get("storage"),
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
+
+    check_pkg_installed("terra")
+
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")
@@ -122,9 +122,7 @@ tar_terra_vect <- function(name,
 #' @noRd
 create_format_terra_vect <- function(filetype, options, ...) {
 
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
+    check_pkg_installed("terra")
 
     # get list of drivers available for writing depending on what the user's GDAL supports
     drv <- terra::gdal(drivers = TRUE)
@@ -161,9 +159,7 @@ create_format_terra_vect <- function(filetype, options, ...) {
 #' @noRd
 create_format_terra_vect_shz <- function(options, ...) {
 
-    if (!requireNamespace("terra")) {
-        stop("package 'terra' is required", call. = FALSE)
-    }
+    check_pkg_installed("terra")
 
     .write_terra_vector <- eval(substitute(function(object, path) {
         terra::writeVector(

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -75,9 +75,7 @@ tar_terra_vect <- function(name,
         tidy_eval = tidy_eval
     )
 
-    # get list of drivers available for writing depending on what the user's GDAL supports
-    drv <- terra::gdal(drivers = TRUE)
-    drv <- drv[drv$type == "vector" & grepl("write", drv$can), ]
+    drv <- get_gdal_available_driver_list("vector")
 
     # if not specified by user, pull the corresponding geotargets option
     filetype <- filetype %||% geotargets_option_get("gdal.vector.driver")
@@ -124,9 +122,7 @@ create_format_terra_vect <- function(filetype, options, ...) {
 
     check_pkg_installed("terra")
 
-    # get list of drivers available for writing depending on what the user's GDAL supports
-    drv <- terra::gdal(drivers = TRUE)
-    drv <- drv[drv$type == "vector" & grepl("write", drv$can), ]
+    drv <- get_gdal_available_driver_list("vector")
 
     if (is.null(filetype)) {
         filetype <- "GeoJSON"

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,3 +4,12 @@ geotargets_repair_option_name <- function(option_name) {
     option_name <- paste0("geotargets.", option_name)
   }
 }
+
+check_pkg_installed <- function(pkg, call = rlang::caller_env()) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    cli::cli_abort(
+        message = "package {.pkg {pkg}} is required",
+        call = call
+    )
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,3 +13,10 @@ check_pkg_installed <- function(pkg, call = rlang::caller_env()) {
     )
   }
 }
+
+get_gdal_available_driver_list <- function(driver_type){
+    # get list of drivers available for writing depending on what the user's GDAL supports
+    drv <- terra::gdal(drivers = TRUE)
+    drv <- drv[drv$type == driver_type & grepl("write", drv$can), ]
+    drv
+}


### PR DESCRIPTION
Closes #10.  Moves `terra` to Suggests and moves check for `terra` to top of `tar_*()` functions.

Also moves validation of `filetype` to `tar_*()` functions. I think this might make error traces more readable to users, but haven't really tested thoroughly