### PR TITLE
create_format_terra_vect: temp fix for issue with replacing function body and {covr}

### DIFF
--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -131,9 +131,9 @@ create_format_terra_vect <- function(filetype, options, ...) {
         terra::writeVector(
             object,
             path,
-            filetype = NULL,
+            filetype = geotargets::geotargets_option_get("gdal.vector.driver"),
             overwrite = TRUE,
-            options = NULL
+            options = geotargets::geotargets_option_get("gdal.vector.creation_options")
         )
     }
     body(.write_terra_vector)[[2]][["filetype"]] <- filetype


### PR DESCRIPTION
This is a workaround for replacement of a function body not working properly within the evaluation environment created by covr, targets tests, and testthat.

More commentary in new issue #38
