### PR TITLE
fix for empty GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS

### DIFF
--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -39,7 +39,7 @@ geotargets_option_get <- function(option_name) {
     get_geotargets_gdal_raster_creation_options <- function(option_name, option_value) {
         gdal_creation_options <- Sys.getenv(
             x = "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS",
-            unset = get_option(option_name, option_value, "")
+            unset = get_option(option_name, option_value, ";")
         )
         the_option <- strsplit(gdal_creation_options, ";")[[1]]
         the_option


### PR DESCRIPTION
In #30 I replaced the `unset` value returned by `Sys.getenv()` for GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS

Calling `strsplit("", ";)[[1]]` returns `character(0)`, which will cause an error in `Sys.getenv()`. This PR gets us the intended default value of `""`