### PR TITLE
`tar_format()` functions: Use `substitute()` into function body rather than `body<-`

### DIFF
--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -109,21 +109,15 @@ create_format_terra_raster <- function(filetype, gdal, ...) {
 
     gdal <- gdal %||% geotargets_option_get("gdal.raster.creation_options")
 
-    # NOTE: Option getting functions are set in the .write_terra_raster function template
-    #       to resolve issue with body<- not working in some evaluation contexts ({covr}).
-    # TODO: It should be fine to have filetype and gdal as NULL
-    .write_terra_raster <- function(object, path) {
+    .write_terra_raster <- eval(substitute(function(object, path) {
         terra::writeRaster(
             object,
             path,
-            filetype = geotargets::geotargets_option_get("gdal.raster.driver"),
+            filetype = filetype,
             overwrite = TRUE,
-            gdal = geotargets::geotargets_option_get("gdal.raster.creation_options")
+            gdal = gdal
         )
-    }
-
-    body(.write_terra_raster)[[2]][["filetype"]] <- filetype
-    body(.write_terra_raster)[[2]][["gdal"]] <- gdal
+    }, list(filetype = filetype, gdal = gdal)))
 
     targets::tar_format(
         read = function(path) terra::rast(path),

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -127,17 +127,15 @@ create_format_terra_vect <- function(filetype, options, ...) {
 
     filetype <- match.arg(filetype, drv$name)
 
-    .write_terra_vector <- function(object, path) {
+    .write_terra_vector <- eval(substitute(function(object, path) {
         terra::writeVector(
             object,
             path,
-            filetype = NULL,
+            filetype = filetype,
             overwrite = TRUE,
-            options = NULL
+            options = options
         )
-    }
-    body(.write_terra_vector)[[2]][["filetype"]] <- filetype
-    body(.write_terra_vector)[[2]][["options"]] <- options
+    }, list(filetype = filetype, options = options)))
 
     targets::tar_format(
         read = function(path) terra::vect(path),
@@ -158,17 +156,16 @@ create_format_terra_vect_shz <- function(options, ...) {
         stop("package 'terra' is required", call. = FALSE)
     }
 
-    .write_terra_vector <- function(object, path) {
+    .write_terra_vector <- eval(substitute(function(object, path) {
         terra::writeVector(
             x = object,
             filename = paste0(path, ".shz"),
             filetype = "ESRI Shapefile",
             overwrite = TRUE,
-            options = NULL
+            options = options
         )
         file.rename(paste0(path, ".shz"), path)
-    }
-    body(.write_terra_vector)[[2]][["options"]] <- options
+    }, list(options = options)))
 
     targets::tar_format(
         read = function(path) terra::vect(paste0("/vsizip/{", path, "}")),


### PR DESCRIPTION
- Uses a simpler approach to updating the read/write function templates used in format creation methods, thanks to Will Landau for suggestion
- Fixes #38 by avoiding the problematic syntax, normal tests and tests in covr now work