### PR TITLE
Fixes after options, terra, and `tar_terra_sprc()` updates

### DIFF
--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -65,7 +65,7 @@ geotargets_option_get <- function(name) {
     opt <- getOption(option_name, default = Sys.getenv(env_name))
 
     #replace empty string from Sys.getenv default with NULL
-    if (opt == "") {
+    if (length(opt) == 1 && opt == "") {
         opt <- NULL
     }
     #return

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -87,7 +87,7 @@ tar_terra_rast <- function(name,
                     path,
                     filetype = Sys.getenv("GEOTARGETS_GDAL_RASTER_DRIVER"),
                     overwrite = TRUE,
-                    gdal = Sys.getenv("GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS")
+                    gdal = strsplit(Sys.getenv("GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS", unset = ";"), ";")[[1]]
                 )
             },
             marshal = function(object) terra::wrap(object),
@@ -104,7 +104,7 @@ tar_terra_rast <- function(name,
             custom_format = targets::tar_resources_custom_format(
                 #these envvars are used in write function of format
                 envvars = c("GEOTARGETS_GDAL_RASTER_DRIVER" = filetype,
-                            "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" = gdal)
+                            "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" = paste0(gdal, collapse = ";"))
             )
         ),
         storage = storage,

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -49,7 +49,7 @@ tar_terra_rast <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
     filetype <- filetype %||% "GTiff"
-    gdal <- gdal %||% "ENCODING=UTF-8"
+    gdal <- gdal %||% character(0)
 
     #check that filetype option is available
     drv <- get_gdal_available_driver_list("raster")

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -92,7 +92,7 @@ tar_terra_sprc <- function(name,
   filetype <- filetype %||% geotargets_option_get("gdal.raster.driver")
   filetype <- rlang::arg_match0(filetype, drv$name)
 
-  gdal <- gdal %||% geotargets_option_get("gdal.raster.creation_options")
+  gdal <- gdal %||% geotargets_option_get("gdal.raster.creation.options")
 
   .write_terra_rasters_sprc <- eval(
       substitute(

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -62,7 +62,7 @@ tar_terra_sprc <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
   filetype <- filetype %||% "GTiff"
-  gdal <- gdal %||% "ENCODING=UTF-8"
+  gdal <- gdal %||% character(0)
 
   # check that filetype option is available
   drv <- get_gdal_available_driver_list("raster")

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -106,7 +106,7 @@ tar_terra_vect <- function(name,
             custom_format = targets::tar_resources_custom_format(
                 #these envvars are used in write function of format
                 envvars = c("GEOTARGETS_GDAL_VECTOR_DRIVER" = filetype,
-                            "GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS" = gdal)
+                            "GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS" = paste0(gdal, collapse = ";"))
             )
         ),
         storage = storage,
@@ -129,7 +129,7 @@ create_format_terra_vect <- function() {
                 path,
                 filetype = Sys.getenv("GEOTARGETS_GDAL_VECTOR_DRIVER"),
                 overwrite = TRUE,
-                options = Sys.getenv("GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS")
+                options = strsplit(Sys.getenv("GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS", unset = ";"), ";")[[1]]
             )
         },
         marshal = function(object) terra::wrap(object),
@@ -151,7 +151,7 @@ create_format_terra_vect_shz <- function() {
                 filename = paste0(path, ".shz"),
                 filetype = "ESRI Shapefile",
                 overwrite = TRUE,
-                options = Sys.getenv("GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS")
+                options = strsplit(Sys.getenv("GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS", unset = ";"), ";")[[1]]
             )
             file.rename(paste0(path, ".shz"), path)
         },

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,9 +15,9 @@ check_pkg_installed <- function(pkg, call = rlang::caller_env()) {
   }
 }
 
-get_gdal_available_driver_list <- function(driver_type){
+get_gdal_available_driver_list <- function(driver_type) {
     # get list of drivers available for writing depending on what the user's GDAL supports
     drv <- terra::gdal(drivers = TRUE)
-    drv <- drv[drv$type == driver_type & grepl("write", drv$can), ]
+    drv <- drv[drv[[driver_type]] & grepl("write", drv$can), ]
     drv
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,6 +18,10 @@ check_pkg_installed <- function(pkg, call = rlang::caller_env()) {
 get_gdal_available_driver_list <- function(driver_type) {
     # get list of drivers available for writing depending on what the user's GDAL supports
     drv <- terra::gdal(drivers = TRUE)
-    drv <- drv[drv[[driver_type]] & grepl("write", drv$can), ]
+    if (utils::packageVersion("terra") > "1.7-74") {
+      drv <- drv[drv[[driver_type]] & grepl("write", drv$can), ]
+    } else {
+      drv <- drv[drv$type == driver_type & grepl("write", drv$can), ]
+    }
     drv
 }

--- a/tests/testthat/_snaps/tar-terra-sprc.md
+++ b/tests/testthat/_snaps/tar-terra-sprc.md
@@ -1,0 +1,14 @@
+# tar_terra_sprc() works
+
+    Code
+      x
+    Output
+      class       : SpatRasterCollection 
+      length      : 2 
+      nrow        : 90, 115 
+      ncol        : 95, 114 
+      nlyr        :  1,   1 
+      extent      : 5.741667, 1558890, 49.44167, 5556741  (xmin, xmax, ymin, ymax)
+      crs (first) : lon/lat WGS 84 (EPSG:4326) 
+      names       : raster_elevs, raster_elevs 
+

--- a/tests/testthat/test-tar-terra-sprc.R
+++ b/tests/testthat/test-tar-terra-sprc.R
@@ -1,6 +1,6 @@
 targets::tar_test("tar_terra_sprc() works", {
   geotargets::geotargets_option_set(
-    "raster_gdal_creation_options",
+    gdal_raster_creation_options =
     c("COMPRESS=DEFLATE", "TFW=YES")
   )
   targets::tar_script({

--- a/tests/testthat/test-tar-terra.R
+++ b/tests/testthat/test-tar-terra.R
@@ -17,26 +17,6 @@ targets::tar_test("tar_terra_rast() works", {
     )
 })
 
-targets::tar_test("tar_terra_rast(zipfile=TRUE) works", {
-    # geotargets::geotargets_option_set(gdal_raster_creation_options = c("COMPRESS=DEFLATE", "TFW=YES"))
-    targets::tar_script({
-        list(
-            geotargets::tar_terra_rast(
-                test_terra_rast2,
-                terra::rast(system.file("ex/elev.tif", package = "terra")),
-                gdal = c("STREAMABLE_OUTPUT=YES", "COMPRESS=NONE"),
-                zipfile = TRUE
-            )
-        )
-    })
-    targets::tar_make()
-    x <- targets::tar_read(test_terra_rast2)
-    expect_s4_class(x, "SpatRaster")
-    expect_snapshot(
-        x
-    )
-})
-
 targets::tar_test("tar_terra_vect() works", {
     targets::tar_script({
         lux_area <- function(projection = "EPSG:4326") {

--- a/tests/testthat/test-tar-terra.R
+++ b/tests/testthat/test-tar-terra.R
@@ -17,6 +17,26 @@ targets::tar_test("tar_terra_rast() works", {
     )
 })
 
+targets::tar_test("tar_terra_rast(zipfile=TRUE) works", {
+    # geotargets::geotargets_option_set(gdal_raster_creation_options = c("COMPRESS=DEFLATE", "TFW=YES"))
+    targets::tar_script({
+        list(
+            geotargets::tar_terra_rast(
+                test_terra_rast2,
+                terra::rast(system.file("ex/elev.tif", package = "terra")),
+                gdal = c("STREAMABLE_OUTPUT=YES", "COMPRESS=NONE"),
+                zipfile = TRUE
+            )
+        )
+    })
+    targets::tar_make()
+    x <- targets::tar_read(test_terra_rast2)
+    expect_s4_class(x, "SpatRaster")
+    expect_snapshot(
+        x
+    )
+})
+
 targets::tar_test("tar_terra_vect() works", {
     targets::tar_script({
         lux_area <- function(projection = "EPSG:4326") {


### PR DESCRIPTION
Here are some things I noticed while bringing the tar-stars (#33) branch up to date. Doing a separate PR as they are not related to the {stars} changes

In this PR:

 - `geotargets_option_get()`: Handle case when `getOption()` returns vector length >1
 
 - `get_gdal_available_driver_list()`: Fix for `terra::gdal(drivers=TRUE)` table format. This has changed in the development version of terra (currently 1.7-75 vs. CRAN 1.7-71). For now handle older package versions differently by checking with `packageVersion()` before subsetting driver list. {terra} now reports drivers similarly to how {sf} does RE: https://github.com/rspatial/terra/issues/1465
   
 - `tar_terra_sprc()`: Fix specification of multiple raster creation options in test and add snapshot 