### PR TITLE
Pass user specified `resources`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,3 +4,4 @@
 * Created `tar_terra_sprc()` that creates a `SpatRasterCollection` object.
 * `geotargets_options_get()` and `geotargets_options_set()` can be used to set and get options specific to `geotargets`.
 * `geotargets` now requires `targets` version 1.7.0 or higher
+* fixed a bug where `resources` supplied to `tar_terra_*()` were being ignored (#66)

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -59,7 +59,7 @@ tar_terra_rast <- function(name,
 
     #ensure that user-passed `resources` doesn't include `custom_format`
     if ("custom_format" %in% names(resources)) {
-        stop("`custom_format` cannot be supplied to targets created with `tar_terra_rast()`")
+        cli::cli_abort("{.val custom_format} cannot be supplied to targets created with {.fn tar_terra_rast}")
     }
 
     name <- targets::tar_deparse_language(substitute(name))

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -108,7 +108,7 @@ tar_terra_rast <- function(name,
         garbage_collection = garbage_collection,
         deployment = deployment,
         priority = priority,
-        resources = modifyList(
+        resources = utils::modifyList(
             targets::tar_resources(
                 custom_format = targets::tar_resources_custom_format(
                     #these envvars are used in write function of format

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -57,6 +57,11 @@ tar_terra_rast <- function(name,
 
     check_pkg_installed("terra")
 
+    #ensure that user-passed `resources` doesn't include `custom_format`
+    if ("custom_format" %in% names(resources)) {
+        stop("`custom_format` cannot be supplied to targets created with `tar_terra_rast()`")
+    }
+
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")
@@ -103,17 +108,18 @@ tar_terra_rast <- function(name,
         garbage_collection = garbage_collection,
         deployment = deployment,
         priority = priority,
-        resources = targets::tar_resources(
-            custom_format = targets::tar_resources_custom_format(
-                #these envvars are used in write function of format
-                envvars = c(
-                    "GEOTARGETS_GDAL_RASTER_DRIVER" = filetype,
-                    "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" = (
-                        paste0(gdal, collapse = ";")
+        resources = modifyList(
+            targets::tar_resources(
+                custom_format = targets::tar_resources_custom_format(
+                    #these envvars are used in write function of format
+                    envvars = c(
+                        "GEOTARGETS_GDAL_RASTER_DRIVER" = filetype,
+                        "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" = (
+                            paste0(gdal, collapse = ";")
                         )
                     )
-            )
-        ),
+                )
+            ), resources),
         storage = storage,
         retrieval = retrieval,
         cue = cue

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -128,7 +128,7 @@ tar_terra_sprc <- function(name,
     deployment = deployment,
     priority = priority,
     resources = targets::tar_resources(
-        custom_format = modifyList(
+        custom_format = utils::modifyList(
             targets::tar_resources_custom_format(
                 #these envvars are used in write function of format
                 envvars = c(

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -127,9 +127,9 @@ tar_terra_sprc <- function(name,
     garbage_collection = garbage_collection,
     deployment = deployment,
     priority = priority,
-    resources = targets::tar_resources(
-        custom_format = utils::modifyList(
-            targets::tar_resources_custom_format(
+    resources = utils::modifyList(
+        targets::tar_resources(
+            custom_format = targets::tar_resources_custom_format(
                 #these envvars are used in write function of format
                 envvars = c(
                     "GEOTARGETS_GDAL_RASTER_DRIVER" = filetype,

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -62,6 +62,10 @@ tar_terra_sprc <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue")) {
   check_pkg_installed("terra")
+    #ensure that user-passed `resources` doesn't include `custom_format`
+    if ("custom_format" %in% names(resources)) {
+        stop("`custom_format` cannot be supplied to targets created with `tar_terra_rast()`")
+    }
 
   gdal <- gdal %||% character(0)
   filetype <- filetype %||% "GTiff"
@@ -124,16 +128,17 @@ tar_terra_sprc <- function(name,
     deployment = deployment,
     priority = priority,
     resources = targets::tar_resources(
-        custom_format = targets::tar_resources_custom_format(
-            #these envvars are used in write function of format
-            envvars = c(
-                "GEOTARGETS_GDAL_RASTER_DRIVER" = filetype,
-                "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" = (
-                    paste0(gdal, collapse = ";")
+        custom_format = modifyList(
+            targets::tar_resources_custom_format(
+                #these envvars are used in write function of format
+                envvars = c(
+                    "GEOTARGETS_GDAL_RASTER_DRIVER" = filetype,
+                    "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" = (
+                        paste0(gdal, collapse = ";")
                     )
+                )
             )
-        )
-    ),
+        ), resources),
     storage = storage,
     retrieval = retrieval,
     cue = cue

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -64,7 +64,7 @@ tar_terra_sprc <- function(name,
   check_pkg_installed("terra")
     #ensure that user-passed `resources` doesn't include `custom_format`
     if ("custom_format" %in% names(resources)) {
-        stop("`custom_format` cannot be supplied to targets created with `tar_terra_sprc()`")
+        cli::cli_abort("{.val custom_format} cannot be supplied to targets created with {.fn tar_terra_sprc}")
     }
 
   gdal <- gdal %||% character(0)

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -64,7 +64,7 @@ tar_terra_sprc <- function(name,
   check_pkg_installed("terra")
     #ensure that user-passed `resources` doesn't include `custom_format`
     if ("custom_format" %in% names(resources)) {
-        stop("`custom_format` cannot be supplied to targets created with `tar_terra_rast()`")
+        stop("`custom_format` cannot be supplied to targets created with `tar_terra_sprc()`")
     }
 
   gdal <- gdal %||% character(0)

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -68,7 +68,7 @@ tar_terra_vect <- function(name,
 
     #ensure that user-passed `resources` doesn't include `custom_format`
     if ("custom_format" %in% names(resources)) {
-        stop("`custom_format` cannot be supplied to targets created with `tar_terra_vect()`")
+        cli::cli_abort("{.val custom_format} cannot be supplied to targets created with {.fn tar_terra_vect}")
     }
 
     name <- targets::tar_deparse_language(substitute(name))

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -107,9 +107,9 @@ tar_terra_vect <- function(name,
         garbage_collection = garbage_collection,
         deployment = deployment,
         priority = priority,
-        resources = targets::tar_resources(
-            custom_format = utils::modifyList(
-                targets::tar_resources_custom_format(
+        resources = utils::modifyList(
+            targets::tar_resources(
+                custom_format = targets::tar_resources_custom_format(
                     #these envvars are used in write function of format
                     envvars = c(
                         "GEOTARGETS_GDAL_VECTOR_DRIVER" = filetype,

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -108,7 +108,7 @@ tar_terra_vect <- function(name,
         deployment = deployment,
         priority = priority,
         resources = targets::tar_resources(
-            custom_format = modifyList(
+            custom_format = utils::modifyList(
                 targets::tar_resources_custom_format(
                     #these envvars are used in write function of format
                     envvars = c(

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -66,6 +66,11 @@ tar_terra_vect <- function(name,
 
     check_pkg_installed("terra")
 
+    #ensure that user-passed `resources` doesn't include `custom_format`
+    if ("custom_format" %in% names(resources)) {
+        stop("`custom_format` cannot be supplied to targets created with `tar_terra_vect()`")
+    }
+
     name <- targets::tar_deparse_language(substitute(name))
 
     envir <- targets::tar_option_get("envir")
@@ -103,16 +108,17 @@ tar_terra_vect <- function(name,
         deployment = deployment,
         priority = priority,
         resources = targets::tar_resources(
-            custom_format = targets::tar_resources_custom_format(
-                #these envvars are used in write function of format
-                envvars = c(
-                    "GEOTARGETS_GDAL_VECTOR_DRIVER" = filetype,
-                    "GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS" = (
-                        paste0(gdal, collapse = ";")
+            custom_format = modifyList(
+                targets::tar_resources_custom_format(
+                    #these envvars are used in write function of format
+                    envvars = c(
+                        "GEOTARGETS_GDAL_VECTOR_DRIVER" = filetype,
+                        "GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS" = (
+                            paste0(gdal, collapse = ";")
                         )
+                    )
                 )
-            )
-        ),
+            ), resources),
         storage = storage,
         retrieval = retrieval,
         cue = cue

--- a/tests/testthat/test-geotargets-option.R
+++ b/tests/testthat/test-geotargets-option.R
@@ -18,7 +18,11 @@ targets::tar_test("geotargets_options_get() retrieves options in correct priorit
     )
 })
 
+
 test_that("geotargets_option_set() works", {
+    op <- getOption("geotargets.gdal.raster.driver")
+    withr::defer(options("geotargets.gdal.raster.driver" = op))
+
     geotargets_option_set(gdal_raster_driver = "COG")
     expect_equal(getOption("geotargets.gdal.raster.driver"), "COG")
     expect_equal(geotargets_option_get("gdal.raster.driver"), "COG")
@@ -26,6 +30,11 @@ test_that("geotargets_option_set() works", {
 })
 
 test_that("options aren't reset with multiple calls to geotargets_option_set()", {
+    op_rast <- getOption("geotargets.gdal.raster.driver")
+    withr::defer(options("geotargets.gdal.raster.driver" = op_rast))
+    op_vect <- getOption("geotargets.gdal.vector.driver")
+    withr::defer(options("geotargets.gdal.vector.driver" = op_vect))
+
     geotargets_option_set(gdal_raster_driver = "GPKG")
     geotargets_option_set(gdal_vector_driver = "GPKG")
     expect_equal(geotargets_option_get("gdal_vector_driver"), "GPKG")

--- a/tests/testthat/test-tar-terra.R
+++ b/tests/testthat/test-tar-terra.R
@@ -1,4 +1,5 @@
 # test_that() #Included to make RStudio recognize this file as a test
+library(targets)
 targets::tar_test("tar_terra_rast() works", {
     # geotargets::geotargets_option_set(gdal_raster_creation_options = c("COMPRESS=DEFLATE", "TFW=YES"))
     targets::tar_script({
@@ -102,6 +103,20 @@ targets::tar_test("user resources are passed correctly", {
     )
     testthat::expect_equal(
         tar_terra_rast(
+            x, 1,
+            resources = tar_resources(crew = tar_resources_crew(controller = "persistent"))
+        )$settings$resources$crew,
+        tar_resources_crew(controller = "persistent")
+    )
+    testthat::expect_equal(
+        tar_terra_vect(
+            x, 1,
+            resources = tar_resources(crew = tar_resources_crew(controller = "persistent"))
+        )$settings$resources$crew,
+        tar_resources_crew(controller = "persistent")
+    )
+    testthat::expect_equal(
+        tar_terra_sprc(
             x, 1,
             resources = tar_resources(crew = tar_resources_crew(controller = "persistent"))
         )$settings$resources$crew,

--- a/tests/testthat/test-tar-terra.R
+++ b/tests/testthat/test-tar-terra.R
@@ -87,3 +87,24 @@ targets::tar_test("tar_terra_vect() works with multiple workers (tests marshalin
     expect_s4_class(targets::tar_read(vect1), "SpatVector")
 })
 
+targets::tar_test("user resources are passed correctly", {
+    persistent <- crew_controller_local(name = "persistent")
+    transient <- crew_controller_local(name = "transient", tasks_max = 1L)
+    targets::tar_option_set(
+        controller = crew_controller_group(persistent, transient),
+        resources = tar_resources(
+            crew = tar_resources_crew(controller = "transient")
+        ))
+    testthat::expect_equal(
+        tar_terra_rast(x, 1)$settings$resources$crew,
+        tar_resources_crew(controller = "transient")
+    )
+    testthat::expect_equal(
+        tar_terra_rast(
+            x, 1,
+            resources = tar_resources(crew = tar_resources_crew(controller = "persistent"))
+        )$settings$resources$crew,
+        tar_resources_crew(controller = "persistent")
+    )
+})
+

--- a/tests/testthat/test-tar-terra.R
+++ b/tests/testthat/test-tar-terra.R
@@ -88,10 +88,11 @@ targets::tar_test("tar_terra_vect() works with multiple workers (tests marshalin
 })
 
 targets::tar_test("user resources are passed correctly", {
-    persistent <- crew_controller_local(name = "persistent")
-    transient <- crew_controller_local(name = "transient", tasks_max = 1L)
+    library(crew)
+    persistent <- crew::crew_controller_local(name = "persistent")
+    transient  <- crew::crew_controller_local(name = "transient", tasks_max = 1L)
     targets::tar_option_set(
-        controller = crew_controller_group(persistent, transient),
+        controller = crew::crew_controller_group(persistent, transient),
         resources = tar_resources(
             crew = tar_resources_crew(controller = "transient")
         ))


### PR DESCRIPTION
Fix for #66.  Uses `utils::modifyList()` to append the user supplied `resources` with those necessary for `tar_terra_*()` to work. Also includes changes to tests that were needed to get `check()` to pass