### PR TITLE
Add CITATION.cff

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^CITATION\.cff$

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,45 @@
+# -----------------------------------------------------------
+# CITATION file created with {cffr} R package, v0.5.0
+# See also: https://docs.ropensci.org/cffr/
+# -----------------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "geotargets" in publications use:'
+type: software
+license: MIT
+title: 'geotargets: Targets extensions for geospatial formats'
+version: 0.0.0.9000
+abstract: Provides extensions for various geospatial file formats, such as shapefiles
+  and rasters. See the vignettes for worked examples and demonstrations and explanations
+  of how to use the various package extensions.
+authors:
+- family-names: Tierney
+  given-names: Nicholas
+  email: nicholas.tierney@gmail.com
+  orcid: https://orcid.org/0000-0003-1460-8722
+- family-names: Scott
+  given-names: Eric
+  orcid: https://orcid.org/0000-0002-7430-7879
+- family-names: Brown
+  given-names: Andrew
+  orcid: https://orcid.org/0000-0002-4565-533X
+repository-code: https://github.com/njtierney/geotargets
+url: https://njtierney.github.io/geotargets/
+contact:
+- family-names: Tierney
+  given-names: Nicholas
+  email: nicholas.tierney@gmail.com
+  orcid: https://orcid.org/0000-0003-1460-8722
+keywords:
+- geospatial
+- pipeline
+- r
+- r-package
+- r-targetopia
+- raster
+- reproducibility
+- reproducible-research
+- rstats
+- targets
+- vector
+- workflow

--- a/R/release_bullets.R
+++ b/R/release_bullets.R
@@ -1,0 +1,6 @@
+#see ?usethis::use_release_issue()
+release_bullets <- function() {
+    c(
+        "update CITATION.cff with `cffr::cff_write(dependencies = FALSE)` (after incrementing version)"
+    )
+}


### PR DESCRIPTION
Adds a CITATION.cff file that will be recognized by GitHub and Zenodo.  Also adds a reminder to update it when using `usethis::use_release_issue()`