### PR TITLE
Fix `tile_blocksize()` to work with multi-layer rasters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # geotargets (development version)
 
 * Created `tar_stars()` and `tar_stars_proxy()` that create `stars` and `stars_proxy` objects, respectively.
-* Created `tar_terra_tiles()`, a "target factory" for splitting a raster into multiple tiles with dynamic branching.
-* Removes the `iteration` argument from all `tar_*()` functions.  `iteration` now hard-coded as `"list"` since it is the only option that works (for now at least).
-* Created two helper functions for use in `tar_terra_tiles()`: `tile_grid()` and `tile_blocksize()`.
+* Created `tar_terra_tiles()`, a "target factory" for splitting a raster into multiple tiles with dynamic branching (#69).
+* Created two helper functions for use in `tar_terra_tiles()`: `tile_grid()` and `tile_blocksize()` (#69, #87, #89).
 * Created utility function `set_window()` mostly for internal use within `tar_terra_tiles()`.
+* Removes the `iteration` argument from all `tar_*()` functions.  `iteration` now hard-coded as `"list"` since it is the only option that works (for now at least).
 * Added the `description` argument to all `tar_*()` functions which is passed to `tar_target()`.
 
 # geotargets 0.1.0 (14 May 2024)

--- a/R/tar_terra_tiles.R
+++ b/R/tar_terra_tiles.R
@@ -286,7 +286,7 @@ tile_grid <- function(raster, ncol, nrow) {
 #' @export
 #' @rdname tile_helpers
 tile_blocksize <- function(raster) {
-    tile_ext <- terra::getTileExtents(raster, terra::fileBlocksize(raster))
+    tile_ext <- terra::getTileExtents(raster, terra::fileBlocksize(raster)[1,])
     n_tiles <- seq_len(nrow(tile_ext))
     tile_list <- lapply(
         n_tiles,

--- a/tests/testthat/test-tar-terra-tiles.R
+++ b/tests/testthat/test-tar-terra-tiles.R
@@ -65,5 +65,7 @@ targets::tar_test("recombined tiles are equal to original", {
     targets::tar_make()
     targets::tar_load(c(my_map, rast_split))
     recombined <- terra::merge(terra::sprc(rast_split))
-    expect_equal(terra::values(my_map), terra::values(recombined))
+    names(recombined) <- names(my_map) <- 1:3 #ignore dimnames because of bug #89
+    expect_equal(terra::values(my_map),
+                 terra::values(recombined))
 })

--- a/tests/testthat/test-tar-terra-tiles.R
+++ b/tests/testthat/test-tar-terra-tiles.R
@@ -47,13 +47,13 @@ targets::tar_test("recombined tiles are equal to original", {
         list(
             tar_target(
                 my_file,
-                # system.file("ex/elev.tif", package="terra"),
-                system.file("ex/logo.tif", package = "terra"),
+                system.file("ex/elev.tif", package = "terra"),
                 format = "file"
             ),
             tar_terra_rast(
                 my_map,
-                terra::rast(my_file)
+                #create multi-layer raster for testing
+                rast(c(my_file, my_file))
             ),
             tar_terra_tiles(
                 name = rast_split,
@@ -65,7 +65,6 @@ targets::tar_test("recombined tiles are equal to original", {
     targets::tar_make()
     targets::tar_load(c(my_map, rast_split))
     recombined <- terra::merge(terra::sprc(rast_split))
-    names(recombined) <- names(my_map) <- 1:3 #ignore dimnames because of bug #89
     expect_equal(terra::values(my_map),
                  terra::values(recombined))
 })

--- a/tests/testthat/test-tar-terra-tiles.R
+++ b/tests/testthat/test-tar-terra-tiles.R
@@ -7,7 +7,8 @@ targets::tar_test("tar_terra_tiles() works", {
         list(
             tar_target(
                 my_file,
-                system.file("ex/elev.tif", package="terra"),
+                # system.file("ex/elev.tif", package="terra"),
+                system.file("ex/logo.tif", package = "terra"),
                 format = "file"
             ),
             tar_terra_rast(
@@ -46,7 +47,8 @@ targets::tar_test("recombined tiles are equal to original", {
         list(
             tar_target(
                 my_file,
-                system.file("ex/elev.tif", package="terra"),
+                # system.file("ex/elev.tif", package="terra"),
+                system.file("ex/logo.tif", package = "terra"),
                 format = "file"
             ),
             tar_terra_rast(


### PR DESCRIPTION
Closes #87 by using only the first row of output from `terra::fileBlocksize()`, which outputs a number of rows and columns *for each layer*.  