### PR TITLE
Adds GDAL min version requirement for writing .shz

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Created utility function `set_window()` mostly for internal use within `tar_terra_tiles()`.
 * Removes the `iteration` argument from all `tar_*()` functions.  `iteration` now hard-coded as `"list"` since it is the only option that works (for now at least).
 * Added the `description` argument to all `tar_*()` functions which is passed to `tar_target()`.
+* Requires GDAL 3.1 or greater to use "ESRI Shapefile" driver in `tar_terra_vect()` (#71, #97)
 
 # geotargets 0.1.0 (14 May 2024)
 

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -161,6 +161,10 @@ create_format_terra_vect <- function() {
 create_format_terra_vect_shz <- function() {
 
     check_pkg_installed("terra")
+    #difficult to test
+    if (terra::gdal(lib = "gdal") < "3.1") {
+        rlang::abort("Writing a .shz file requires GDAL version 3.1 or greater")
+    }
 
     targets::tar_format(
         read = function(path) terra::vect(paste0("/vsizip/{", path, "}")),

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -162,9 +162,7 @@ create_format_terra_vect_shz <- function() {
 
     check_pkg_installed("terra")
     #difficult to test
-    if (terra::gdal(lib = "gdal") < "3.1") {
-        rlang::abort("Writing a .shz file requires GDAL version 3.1 or greater")
-    }
+    check_gdal_shz(min_version = "3.1")
 
     targets::tar_format(
         read = function(path) terra::vect(paste0("/vsizip/{", path, "}")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,15 +15,13 @@ check_pkg_installed <- function(pkg, call = rlang::caller_env()) {
   }
 }
 
-check_gdal_version <- function(min_version = "3.1") {
-    terra_gdal <- numeric_version(terra::gdal(lib = "gdal"))
-    version <- numeric_version(min_version)
-    terra_gdal < min_version
+gdal_version <- function() {
+    numeric_version(terra::gdal(lib = "gdal"))
 }
 
 check_gdal_shz <- function(min_version = "3.1",
                            call = rlang::caller_env()){
-    if (check_gdal_version(min_version)) {
+    if (gdal_version() < numeric_version(min_version)) {
         cli::cli_abort(
             message = c(
                 "Must have {.pkg GDAL} version {.val {min_version}} or greater",

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,6 +15,26 @@ check_pkg_installed <- function(pkg, call = rlang::caller_env()) {
   }
 }
 
+check_gdal_version <- function(min_version = "3.1") {
+    terra_gdal <- numeric_version(terra::gdal(lib = "gdal"))
+    version <- numeric_version(min_version)
+    terra_gdal < min_version
+}
+
+check_gdal_shz <- function(min_version = "3.1",
+                           call = rlang::caller_env()){
+    if (check_gdal_version(min_version)) {
+        cli::cli_abort(
+            message = c(
+                "Must have {.pkg GDAL} version {.val {min_version}} or greater",
+                "i" = "To write a {.val .shz} file requires GDAL version \\
+        {.val {min_version}} or greater"
+            ),
+            call = call
+        )
+    }
+}
+
 get_gdal_available_driver_list <- function(driver_type) {
     # get list of drivers available for writing depending on what the user's GDAL supports
     drv <- terra::gdal(drivers = TRUE)

--- a/tests/testthat/_snaps/check-gdal-shz.md
+++ b/tests/testthat/_snaps/check-gdal-shz.md
@@ -1,0 +1,9 @@
+# GDAL version checked checked
+
+    Code
+      check_gdal_shz()
+    Condition
+      Error:
+      ! Must have GDAL version "3.1" or greater
+      i To write a ".shz" file requires GDAL version "3.1" or greater
+

--- a/tests/testthat/test-check-gdal-shz.R
+++ b/tests/testthat/test-check-gdal-shz.R
@@ -1,0 +1,9 @@
+test_that("GDAL version checked checked", {
+    local_mocked_bindings(
+        check_gdal_version = function(...) TRUE
+    )
+    expect_snapshot(
+        error = TRUE,
+        check_gdal_shz()
+    )
+})

--- a/tests/testthat/test-check-gdal-shz.R
+++ b/tests/testthat/test-check-gdal-shz.R
@@ -1,6 +1,6 @@
 test_that("GDAL version checked checked", {
     local_mocked_bindings(
-        check_gdal_version = function(...) TRUE
+        gdal_version = function(...) "3.0.0"
     )
     expect_snapshot(
         error = TRUE,


### PR DESCRIPTION
Closes #71 by adding a check for GDAL 3.1 or greater.  Not sure if there is a way to write a test for this