### PR TITLE
Simpler `tar_format()` with `targets` 1.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Language: en-GB
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 
-    targets (>= 1.7.0),
+    targets (>= 1.8.0),
     rlang (>= 1.1.3),
     cli (>= 3.6.2)
 Suggests: 

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -213,7 +213,7 @@ tar_stars_raw <- function(name,
         format = targets::tar_format(
             read = function(path) {
                 if (ncdf) {
-                    check_pkg_installed("ncmeta")
+                    geotargets:::check_pkg_installed("ncmeta")
                     stars::read_ncdf(path, proxy = proxy)
                 } else if (isTRUE(mdim)) {
                     stars::read_mdim(path, proxy = proxy)

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -204,52 +204,6 @@ tar_stars_raw <- function(name,
 
     driver <- rlang::arg_match0(driver, drv$name)
 
-    .read_stars <- eval(substitute(
-        function(path) {
-
-        ## TODO: it appears envvar custom resources do not work in read function?
-        READ_FUN <- stars::read_stars
-        #  mdim <- as.logical(Sys.getenv("GEOTARGETS_GDAL_RASTER_MDIM", unset = FALSE))
-        if (mdim) {
-            READ_FUN <- stars::read_mdim
-        }
-
-        # ncdf <- as.logical(Sys.getenv("GEOTARGETS_USE_NCMETA", unset = FALSE))
-        if (ncdf && requireNamespace("ncmeta")) {
-            READ_FUN <- stars::read_ncdf
-        }
-
-        # proxy <- as.logical(Sys.getenv("GEOTARGETS_PROXY", unset = FALSE))
-        READ_FUN(path, proxy = proxy)
-
-    }, list(ncdf = ncdf, mdim = mdim, proxy = proxy)))
-
-    # TODO: should multidimensional array use the same `options` as 2D?
-    .write_stars <- function(object, path) {
-
-        WRITE_FUN <- stars::write_stars
-
-        mdim <- as.logical(Sys.getenv("GEOTARGETS_GDAL_RASTER_MDIM",
-                                      unset = FALSE))
-        if (mdim) {
-            WRITE_FUN <- stars::write_mdim
-        }
-
-        dr <- Sys.getenv("GEOTARGETS_GDAL_RASTER_DRIVER")
-
-        # stars requires character(0), not "", for no options set
-        co <- Sys.getenv("GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS")
-        co2 <- strsplit(co, ";")[[1]]
-
-        WRITE_FUN(
-            object,
-            path,
-            overwrite = TRUE,
-            driver = dr,
-            options = co
-        )
-    }
-
     targets::tar_target_raw(
         name = name,
         command = command,
@@ -257,10 +211,42 @@ tar_stars_raw <- function(name,
         packages = packages,
         library = library,
         format = targets::tar_format(
-            read = .read_stars,
-            write = .write_stars,
-            marshal = function(object) object, # Not currently used
-            unmarshal = function(object) object
+            read = function(path) {
+                if (ncdf && requireNamespace("ncmeta")) {
+                    stars::read_ncdf(path, proxy = proxy)
+                } else if (isTRUE(mdim)) {
+                    stars::read_mdim(path, proxy = proxy)
+                } else {
+                    stars::read_stars(path, proxy = proxy)
+                }
+            },
+            write = function(object, path) {
+                if (mdim) {
+                    stars::write_mdim(
+                        object,
+                        path,
+                        overwrite = TRUE,
+                        driver = driver,
+                        options = options
+                    )
+                } else {
+                    stars::write_stars(
+                        object,
+                        path,
+                        overwrite = TRUE,
+                        driver = driver,
+                        options = options
+                    )
+                }
+
+            },
+            substitute = list(
+                ncdf = ncdf,
+                mdim = mdim,
+                proxy = proxy,
+                driver = driver,
+                options = options
+            )
         ),
         repository = repository,
         iteration = "list", #the only option that works
@@ -269,17 +255,7 @@ tar_stars_raw <- function(name,
         garbage_collection = garbage_collection,
         deployment = deployment,
         priority = priority,
-        resources = utils::modifyList(targets::tar_resources(
-            custom_format = targets::tar_resources_custom_format(
-                #these envvars are used in read and write functions of format
-                envvars = c("GEOTARGETS_GDAL_RASTER_DRIVER" = driver,
-                            "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" =
-                                paste0(options, collapse = ";"),
-                            "GEOTARGETS_GDAL_RASTER_MDIM" = mdim,
-                            "GEOTARGETS_PROXY" = proxy,
-                            "GEOTARGETS_USE_NCMETA" = ncdf)
-            )
-        ), resources),
+        resources = resources,
         storage = storage,
         retrieval = retrieval,
         cue = cue,

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -212,7 +212,8 @@ tar_stars_raw <- function(name,
         library = library,
         format = targets::tar_format(
             read = function(path) {
-                if (ncdf && requireNamespace("ncmeta")) {
+                if (ncdf) {
+                    check_pkg_installed("ncmeta")
                     stars::read_ncdf(path, proxy = proxy)
                 } else if (isTRUE(mdim)) {
                     stars::read_mdim(path, proxy = proxy)

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -53,13 +53,14 @@ tar_terra_rast <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue"),
                            description = targets::tar_option_get("description")) {
+    check_pkg_installed("terra")
+
     filetype <- filetype %||% "GTiff"
 
     #check that filetype option is available
     drv <- get_gdal_available_driver_list("raster")
     filetype <- rlang::arg_match0(filetype, drv$name)
 
-    check_pkg_installed("terra")
 
     #ensure that user-passed `resources` doesn't include `custom_format`
     if ("custom_format" %in% names(resources)) {

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -62,6 +62,8 @@ tar_terra_vect <- function(name,
                            retrieval = targets::tar_option_get("retrieval"),
                            cue = targets::tar_option_get("cue"),
                            description = targets::tar_option_get("description")) {
+    check_pkg_installed("terra")
+
     filetype <- filetype %||% "GeoJSON"
     gdal <- gdal %||% "ENCODING=UTF-8"
 
@@ -69,7 +71,6 @@ tar_terra_vect <- function(name,
     drv <- get_gdal_available_driver_list("vector")
     filetype <- rlang::arg_match0(filetype, drv$name)
 
-    check_pkg_installed("terra")
 
     #ensure that user-passed `resources` doesn't include `custom_format`
     if ("custom_format" %in% names(resources)) {
@@ -91,20 +92,36 @@ tar_terra_vect <- function(name,
         tidy_eval = tidy_eval
     )
 
-    format <- ifelse(
-        test = filetype == "ESRI Shapefile",
-        #special handling of ESRI shapefiles because the output is a dir of multiple files.
-        yes = create_format_terra_vect_shz(),
-        no =  create_format_terra_vect()
-    )
-
     targets::tar_target_raw(
         name = name,
         command = command,
         pattern = pattern,
         packages = packages,
         library = library,
-        format = format,
+        format = targets::tar_format(
+            read = function(path) {
+                if (filetype == "ESRI Shapefile") {
+                    terra::vect(paste0("/vsizip/{", path, "}"))
+                } else {
+                    terra::vect(path)
+                }
+            },
+            write = function(object, path) {
+                terra::writeVector(
+                    object,
+                    filename = ifelse(filetype == "ESRI Shapefile", paste0(path, ".shz"), path),
+                    filetype = filetype,
+                    overwrite = TRUE,
+                    options = gdal
+                )
+                if (filetype == "ESRI Shapefile") {
+                    file.rename(paste0(path, ".shz"), path)
+                }
+            },
+            marshal = function(object) terra::wrap(object),
+            unmarshal = function(object) terra::unwrap(object),
+            substitute = list(filetype = filetype, gdal = gdal)
+        ),
         repository = repository,
         iteration = "list",  #only "list" works for now
         error = error,
@@ -112,72 +129,10 @@ tar_terra_vect <- function(name,
         garbage_collection = garbage_collection,
         deployment = deployment,
         priority = priority,
-        resources = utils::modifyList(
-            targets::tar_resources(
-                custom_format = targets::tar_resources_custom_format(
-                    #these envvars are used in write function of format
-                    envvars = c(
-                        "GEOTARGETS_GDAL_VECTOR_DRIVER" = filetype,
-                        "GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS" = (
-                            paste0(gdal, collapse = ";")
-                        )
-                    )
-                )
-            ), resources),
+        resources =  resources,
         storage = storage,
         retrieval = retrieval,
         cue = cue,
         description = description
-    )
-}
-
-
-#' @noRd
-create_format_terra_vect <- function() {
-
-    check_pkg_installed("terra")
-
-    targets::tar_format(
-        read = function(path) terra::vect(path),
-        write = function(object, path) {
-            terra::writeVector(
-                object,
-                path,
-                filetype = Sys.getenv("GEOTARGETS_GDAL_VECTOR_DRIVER"),
-                overwrite = TRUE,
-                options = strsplit(
-                    Sys.getenv("GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS",
-                               unset = ";"),
-                    ";")[[1]]
-            )
-        },
-        marshal = function(object) terra::wrap(object),
-        unmarshal = function(object) terra::unwrap(object)
-    )
-}
-
-#' Special handling for ESRI Shapefiles
-#' @noRd
-create_format_terra_vect_shz <- function() {
-
-    check_pkg_installed("terra")
-
-    targets::tar_format(
-        read = function(path) terra::vect(paste0("/vsizip/{", path, "}")),
-        write = function(object, path) {
-            terra::writeVector(
-                x = object,
-                filename = paste0(path, ".shz"),
-                filetype = "ESRI Shapefile",
-                overwrite = TRUE,
-                options = strsplit(
-                    Sys.getenv("GEOTARGETS_GDAL_VECTOR_CREATION_OPTIONS",
-                               unset = ";"),
-                    ";")[[1]]
-            )
-            file.rename(paste0(path, ".shz"), path)
-        },
-        marshal = function(object) terra::wrap(object),
-        unmarshal = function(object) terra::unwrap(object)
     )
 }

--- a/R/tar_terra_tiles.R
+++ b/R/tar_terra_tiles.R
@@ -168,16 +168,14 @@ tar_terra_tiles_raw <- function(
                 terra::writeRaster(
                     object,
                     path,
-                    filetype = Sys.getenv("GEOTARGETS_GDAL_RASTER_DRIVER"),
+                    filetype = filetype,
                     overwrite = TRUE,
-                    gdal = strsplit(
-                        Sys.getenv("GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS",
-                                   unset = ";"),
-                        ";")[[1]]
+                    gdal = gdal
                 )
             },
             marshal = function(object) terra::wrap(object),
-            unmarshal = function(object) terra::unwrap(object)
+            unmarshal = function(object) terra::unwrap(object),
+            substitute = list(filetype = filetype, gdal = gdal)
         ),
         repository = repository,
         iteration = "list", #only list works (for now at least)
@@ -186,18 +184,7 @@ tar_terra_tiles_raw <- function(
         garbage_collection = garbage_collection,
         deployment = deployment,
         priority = priority,
-        resources = utils::modifyList(
-            targets::tar_resources(
-                custom_format = targets::tar_resources_custom_format(
-                    #these envvars are used in write function of format
-                    envvars = c(
-                        "GEOTARGETS_GDAL_RASTER_DRIVER" = filetype,
-                        "GEOTARGETS_GDAL_RASTER_CREATION_OPTIONS" = (
-                            paste0(gdal, collapse = ";")
-                        )
-                    )
-                )
-            ), resources),
+        resources = resources,
         storage = storage,
         retrieval = retrieval,
         cue = cue,

--- a/man/tar_stars.Rd
+++ b/man/tar_stars.Rd
@@ -57,8 +57,13 @@ tar_stars_proxy(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target. A target
-name must be a valid name for a symbol in R, and it
+\item{name}{Symbol, name of the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
+\code{tar_target(name = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
+\code{tar_target_raw(name = "data")}.
+
+A target name must be a valid name for a symbol in R, and it
 must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
@@ -73,10 +78,20 @@ You can recover the seed of a completed target
 with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
 on the result to locally recreate the target's initial RNG state.}
 
-\item{command}{R code to run the target.}
+\item{command}{R code to run the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
+\code{tar_target(command = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(command = quote(data))}.}
 
-\item{pattern}{Language to define branching for a target.
-For example, in a pipeline with numeric vector targets \code{x} and \code{y},
+\item{pattern}{Code to define a dynamic branching branching for a target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
+\code{tar_target(pattern = map(data))}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(pattern = quote(map(data)))}.
+
+To demonstrate dynamic branching patterns, suppose we have
+a pipeline with numeric vector targets \code{x} and \code{y}. Then,
 \code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
 branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
 and so on. See the user manual for details.}
@@ -121,6 +136,8 @@ for details for instructions.
 See the cloud storage section of
 \url{https://books.ropensci.org/targets/data.html}
 for details for instructions.
+\item A character string from \code{\link[targets:tar_repository_cas]{tar_repository_cas()}} for content-addressable
+storage.
 }
 
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
@@ -134,13 +151,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[targets:tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.
@@ -267,5 +296,5 @@ if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\code{\link[targets:tar_target_raw]{targets::tar_target_raw()}}
+\code{\link[targets:tar_target]{targets::tar_target_raw()}}
 }

--- a/man/tar_terra_rast.Rd
+++ b/man/tar_terra_rast.Rd
@@ -28,8 +28,13 @@ tar_terra_rast(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target. A target
-name must be a valid name for a symbol in R, and it
+\item{name}{Symbol, name of the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
+\code{tar_target(name = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
+\code{tar_target_raw(name = "data")}.
+
+A target name must be a valid name for a symbol in R, and it
 must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
@@ -44,10 +49,20 @@ You can recover the seed of a completed target
 with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
 on the result to locally recreate the target's initial RNG state.}
 
-\item{command}{R code to run the target.}
+\item{command}{R code to run the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
+\code{tar_target(command = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(command = quote(data))}.}
 
-\item{pattern}{Language to define branching for a target.
-For example, in a pipeline with numeric vector targets \code{x} and \code{y},
+\item{pattern}{Code to define a dynamic branching branching for a target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
+\code{tar_target(pattern = map(data))}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(pattern = quote(map(data)))}.
+
+To demonstrate dynamic branching patterns, suppose we have
+a pipeline with numeric vector targets \code{x} and \code{y}. Then,
 \code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
 branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
 and so on. See the user manual for details.}
@@ -88,6 +103,8 @@ for details for instructions.
 See the cloud storage section of
 \url{https://books.ropensci.org/targets/data.html}
 for details for instructions.
+\item A character string from \code{\link[targets:tar_repository_cas]{tar_repository_cas()}} for content-addressable
+storage.
 }
 
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
@@ -101,13 +118,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[targets:tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.
@@ -235,5 +264,5 @@ if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 }
 }
 \seealso{
-\code{\link[targets:tar_target_raw]{targets::tar_target_raw()}}
+\code{\link[targets:tar_target]{targets::tar_target_raw()}}
 }

--- a/man/tar_terra_sds.Rd
+++ b/man/tar_terra_sds.Rd
@@ -28,8 +28,13 @@ tar_terra_sds(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target. A target
-name must be a valid name for a symbol in R, and it
+\item{name}{Symbol, name of the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
+\code{tar_target(name = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
+\code{tar_target_raw(name = "data")}.
+
+A target name must be a valid name for a symbol in R, and it
 must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
@@ -44,10 +49,20 @@ You can recover the seed of a completed target
 with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
 on the result to locally recreate the target's initial RNG state.}
 
-\item{command}{R code to run the target.}
+\item{command}{R code to run the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
+\code{tar_target(command = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(command = quote(data))}.}
 
-\item{pattern}{Language to define branching for a target.
-For example, in a pipeline with numeric vector targets \code{x} and \code{y},
+\item{pattern}{Code to define a dynamic branching branching for a target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
+\code{tar_target(pattern = map(data))}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(pattern = quote(map(data)))}.
+
+To demonstrate dynamic branching patterns, suppose we have
+a pipeline with numeric vector targets \code{x} and \code{y}. Then,
 \code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
 branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
 and so on. See the user manual for details.}
@@ -88,6 +103,8 @@ for details for instructions.
 See the cloud storage section of
 \url{https://books.ropensci.org/targets/data.html}
 for details for instructions.
+\item A character string from \code{\link[targets:tar_repository_cas]{tar_repository_cas()}} for content-addressable
+storage.
 }
 
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
@@ -101,13 +118,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[targets:tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.
@@ -243,7 +272,7 @@ if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 }
 }
 \seealso{
-\code{\link[targets:tar_target_raw]{targets::tar_target_raw()}}, \code{\link[=tar_terra_sprc]{tar_terra_sprc()}}
+\code{\link[targets:tar_target]{targets::tar_target_raw()}}, \code{\link[=tar_terra_sprc]{tar_terra_sprc()}}
 }
 \author{
 Andrew Gene Brown

--- a/man/tar_terra_sprc.Rd
+++ b/man/tar_terra_sprc.Rd
@@ -28,8 +28,13 @@ tar_terra_sprc(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target. A target
-name must be a valid name for a symbol in R, and it
+\item{name}{Symbol, name of the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
+\code{tar_target(name = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
+\code{tar_target_raw(name = "data")}.
+
+A target name must be a valid name for a symbol in R, and it
 must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
@@ -44,10 +49,20 @@ You can recover the seed of a completed target
 with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
 on the result to locally recreate the target's initial RNG state.}
 
-\item{command}{R code to run the target.}
+\item{command}{R code to run the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
+\code{tar_target(command = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(command = quote(data))}.}
 
-\item{pattern}{Language to define branching for a target.
-For example, in a pipeline with numeric vector targets \code{x} and \code{y},
+\item{pattern}{Code to define a dynamic branching branching for a target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
+\code{tar_target(pattern = map(data))}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(pattern = quote(map(data)))}.
+
+To demonstrate dynamic branching patterns, suppose we have
+a pipeline with numeric vector targets \code{x} and \code{y}. Then,
 \code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
 branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
 and so on. See the user manual for details.}
@@ -88,6 +103,8 @@ for details for instructions.
 See the cloud storage section of
 \url{https://books.ropensci.org/targets/data.html}
 for details for instructions.
+\item A character string from \code{\link[targets:tar_repository_cas]{tar_repository_cas()}} for content-addressable
+storage.
 }
 
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
@@ -101,13 +118,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[targets:tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.
@@ -247,7 +276,7 @@ if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 }
 }
 \seealso{
-\code{\link[targets:tar_target_raw]{targets::tar_target_raw()}}
+\code{\link[targets:tar_target]{targets::tar_target_raw()}}
 }
 \author{
 Andrew Gene Brown

--- a/man/tar_terra_tiles.Rd
+++ b/man/tar_terra_tiles.Rd
@@ -27,8 +27,13 @@ tar_terra_tiles(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target. A target
-name must be a valid name for a symbol in R, and it
+\item{name}{Symbol, name of the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
+\code{tar_target(name = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
+\code{tar_target_raw(name = "data")}.
+
+A target name must be a valid name for a symbol in R, and it
 must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
@@ -82,6 +87,8 @@ for details for instructions.
 See the cloud storage section of
 \url{https://books.ropensci.org/targets/data.html}
 for details for instructions.
+\item A character string from \code{\link[targets:tar_repository_cas]{tar_repository_cas()}} for content-addressable
+storage.
 }
 
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
@@ -95,13 +102,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[targets:tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.

--- a/man/tar_terra_vect.Rd
+++ b/man/tar_terra_vect.Rd
@@ -28,8 +28,13 @@ tar_terra_vect(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target. A target
-name must be a valid name for a symbol in R, and it
+\item{name}{Symbol, name of the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
+\code{tar_target(name = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
+\code{tar_target_raw(name = "data")}.
+
+A target name must be a valid name for a symbol in R, and it
 must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
@@ -44,10 +49,20 @@ You can recover the seed of a completed target
 with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
 on the result to locally recreate the target's initial RNG state.}
 
-\item{command}{R code to run the target.}
+\item{command}{R code to run the target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
+\code{tar_target(command = data)}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(command = quote(data))}.}
 
-\item{pattern}{Language to define branching for a target.
-For example, in a pipeline with numeric vector targets \code{x} and \code{y},
+\item{pattern}{Code to define a dynamic branching branching for a target.
+In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
+\code{tar_target(pattern = map(data))}.
+In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
+\code{tar_target_raw(pattern = quote(map(data)))}.
+
+To demonstrate dynamic branching patterns, suppose we have
+a pipeline with numeric vector targets \code{x} and \code{y}. Then,
 \code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
 branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
 and so on. See the user manual for details.}
@@ -88,6 +103,8 @@ for details for instructions.
 See the cloud storage section of
 \url{https://books.ropensci.org/targets/data.html}
 for details for instructions.
+\item A character string from \code{\link[targets:tar_repository_cas]{tar_repository_cas()}} for content-addressable
+storage.
 }
 
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
@@ -101,13 +118,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[targets:tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.

--- a/tests/testthat/test-tar-terra.R
+++ b/tests/testthat/test-tar-terra.R
@@ -166,3 +166,38 @@ targets::tar_test("user resources are passed correctly", {
     )
 })
 
+tar_test("That changing filetype invalidates a target", {
+    targets::tar_script({
+        library(targets)
+        library(geotargets)
+        library(terra)
+
+        list(
+            tar_terra_rast(
+                r,
+                rast(system.file("ex/elev.tif", package="terra")),
+                filetype = "COG"
+            )
+        )
+    })
+    tar_make()
+    first <- tar_meta()$time[2]
+    targets::tar_script({
+        library(targets)
+        library(geotargets)
+        library(terra)
+
+        list(
+            tar_terra_rast(
+                r,
+                rast(system.file("ex/elev.tif", package="terra")),
+                filetype = "GTiff"
+            )
+        )
+    })
+    tar_make()
+    second <- tar_meta()$time[2]
+    #There's gotta be a better way to test if a target is invalidated
+    expect_gt(second, first)
+
+})

--- a/tests/testthat/test-tar-terra.R
+++ b/tests/testthat/test-tar-terra.R
@@ -181,7 +181,7 @@ tar_test("That changing filetype invalidates a target", {
         )
     })
     tar_make()
-    first <- tar_meta()$time[2]
+
     targets::tar_script({
         library(targets)
         library(geotargets)
@@ -195,9 +195,5 @@ tar_test("That changing filetype invalidates a target", {
             )
         )
     })
-    tar_make()
-    second <- tar_meta()$time[2]
-    #There's gotta be a better way to test if a target is invalidated
-    expect_gt(second, first)
-
+    expect_equal(tar_outdated(), "r")
 })


### PR DESCRIPTION
The newest release of `targets` (1.8.0) introduces a new way to pass arguments to custom read and write functions inside of `tar_format()` using a `substitute` argument (#101).  This makes the code a little bit cleaner (no more passing of environment variables with the `resources` argument) and happens to fix an issue where changing the `filetype` argument didn't invalidate the target (#103).

Since we use @inheritParams quite a bit, the documentation for `geotargets` is also updated, sometimes in ways that seem less than ideal (e.g. mentioning specifically `tar_target()` and `tar_target_raw()`.  I suggest that any edits to documentation be dealt with in a separate PR.