### PR TITLE
Suppress `tar_terra_sprc()` warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Created utility function `set_window()` mostly for internal use within `tar_terra_tiles()`.
 * Removes the `iteration` argument from all `tar_*()` functions.  `iteration` now hard-coded as `"list"` since it is the only option that works (for now at least).
 * Added the `description` argument to all `tar_*()` functions which is passed to `tar_target()`.
-* Suppressed the warning "[rast] skipped sub-datasets" from `tar_terra_sprc()`, which is misleading in this context (#92, #104)
+* Suppressed the warning "[rast] skipped sub-datasets" from `tar_terra_sprc()`, which is misleading in this context (#92, #104).
 * Requires GDAL 3.1 or greater to use "ESRI Shapefile" driver in `tar_terra_vect()` (#71, #97)
 
 # geotargets 0.1.0 (14 May 2024)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Created utility function `set_window()` mostly for internal use within `tar_terra_tiles()`.
 * Removes the `iteration` argument from all `tar_*()` functions.  `iteration` now hard-coded as `"list"` since it is the only option that works (for now at least).
 * Added the `description` argument to all `tar_*()` functions which is passed to `tar_target()`.
+* Suppressed the warning "[rast] skipped sub-datasets" from `tar_terra_sprc()`, which is misleading in this context (#92, #104)
 
 # geotargets 0.1.0 (14 May 2024)
 

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -318,12 +318,26 @@ format_terra_collections <- function(type = c("sprc", "sds")) {
                 } else {
                     opt <- ""
                 }
-                terra::writeRaster(
-                    x = object[i],
-                    filename = path,
-                    filetype = Sys.getenv("GEOTARGETS_GDAL_RASTER_DRIVER"),
-                    overwrite = (i == 1),
-                    gdal = c(opt, gdal)
+                withCallingHandlers(
+                    warning = function(cnd) {
+                        # The warning message "[rast] skipped sub-datasets..."
+                        # is printed because the return value of writeRaster()
+                        # is rast(<output>).  In this context it is not
+                        # informative since the write function is sprc(), not
+                        # rast()
+                        if (grepl("\\[rast\\] skipped sub-datasets", cnd$message)) {
+                            rlang::cnd_muffle(cnd)
+                        } else {
+                            warning(cnd$message)
+                        }
+                    },
+                    terra::writeRaster(
+                        x = object[i],
+                        filename = path,
+                        filetype = Sys.getenv("GEOTARGETS_GDAL_RASTER_DRIVER"),
+                        overwrite = (i == 1),
+                        gdal = c(opt, gdal)
+                    )
                 )
             }
         },

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -323,7 +323,7 @@ format_terra_collections <- function(type = c("sprc", "sds")) {
                         # The warning message "[rast] skipped sub-datasets..."
                         # is printed because the return value of writeRaster()
                         # is rast(<output>).  In this context it is not
-                        # informative since the write function is sprc(), not
+                        # informative since the read function is sprc(), not
                         # rast()
                         if (grepl("\\[rast\\] skipped sub-datasets", cnd$message)) {
                             rlang::cnd_muffle(cnd)

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -327,8 +327,6 @@ format_terra_collections <- function(type = c("sprc", "sds")) {
                         # rast()
                         if (grepl("\\[rast\\] skipped sub-datasets", cnd$message)) {
                             rlang::cnd_muffle(cnd)
-                        } else {
-                            warning(cnd$message)
                         }
                     },
                     terra::writeRaster(

--- a/tests/testthat/test-tar-terra-sprc.R
+++ b/tests/testthat/test-tar-terra-sprc.R
@@ -54,7 +54,7 @@ targets::tar_test("tar_terra_sds() works", {
             geotargets::tar_terra_sds(
                 raster_elevs,
                 # two rasters, one unaltered, one scaled by factor of 2
-                command = terra::sprc(list(
+                command = terra::sds(list(
                     elev_scale(1),
                     elev_scale(2)
                 ))
@@ -96,8 +96,6 @@ test_that("wrapped write function doesn't print warning", {
             warning = function(cnd) {
                 if (grepl("\\[rast\\] skipped sub-datasets", cnd$message)) {
                     rlang::cnd_muffle(cnd)
-                } else {
-                    warning(cnd$message)
                 }
             },
             terra::writeRaster(
@@ -108,5 +106,21 @@ test_that("wrapped write function doesn't print warning", {
                 gdal = "APPEND_SUBDATASET=YES"
             )
         )
+    )
+
+    #other warnings should still make it through
+    expect_warning(
+        withCallingHandlers(
+            warning = function(cnd) {
+                if (grepl("\\[rast\\] skipped sub-datasets", cnd$message)) {
+                    rlang::cnd_muffle(cnd)
+                }
+            },
+            terra::writeRaster(
+                x = object[1],
+                filename = withr::local_tempfile(fileext = ".nc")
+            )
+        ),
+        "consider writeCDF to write ncdf files"
     )
 })

--- a/tests/testthat/test-tar-terra-sprc.R
+++ b/tests/testthat/test-tar-terra-sprc.R
@@ -1,38 +1,38 @@
 # test_that() #Included to make RStudio recognize this file as a test
 targets::tar_test("tar_terra_sprc() works", {
-  geotargets::geotargets_option_set(
-    gdal_raster_creation_options =
-    c("COMPRESS=DEFLATE", "TFW=YES")
-  )
-  targets::tar_script({
-    elev_scale <- function(z = 1, projection = "EPSG:4326") {
-      terra::project(
-        terra::rast(
-          system.file(
-            "ex",
-            "elev.tif",
-            package = "terra"
-          )
-        ) * z,
-        projection
-      )
-    }
-    list(
-      geotargets::tar_terra_sprc(
-        raster_elevs,
-        # two rasters, one unaltered, one scaled by factor of 2 and
-        # reprojected to interrupted good homolosine
-        command = terra::sprc(list(
-          elev_scale(1),
-          elev_scale(2, "+proj=igh")
-        ))
-      )
+    geotargets::geotargets_option_set(
+        gdal_raster_creation_options =
+            c("COMPRESS=DEFLATE", "TFW=YES")
     )
-  })
-  targets::tar_make()
-  x <- targets::tar_read(raster_elevs)
-  expect_s4_class(x, "SpatRasterCollection")
-  expect_snapshot(x)
+    targets::tar_script({
+        elev_scale <- function(z = 1, projection = "EPSG:4326") {
+            terra::project(
+                terra::rast(
+                    system.file(
+                        "ex",
+                        "elev.tif",
+                        package = "terra"
+                    )
+                ) * z,
+                projection
+            )
+        }
+        list(
+            geotargets::tar_terra_sprc(
+                raster_elevs,
+                # two rasters, one unaltered, one scaled by factor of 2 and
+                # reprojected to interrupted good homolosine
+                command = terra::sprc(list(
+                    elev_scale(1),
+                    elev_scale(2, "+proj=igh")
+                ))
+            )
+        )
+    })
+    targets::tar_make()
+    x <- targets::tar_read(raster_elevs)
+    expect_s4_class(x, "SpatRasterCollection")
+    expect_snapshot(x)
 })
 
 targets::tar_test("tar_terra_sds() works", {
@@ -42,13 +42,13 @@ targets::tar_test("tar_terra_sds() works", {
     )
     targets::tar_script({
         elev_scale <- function(z = 1) {
-                terra::rast(
-                    system.file(
-                        "ex",
-                        "elev.tif",
-                        package = "terra"
-                    )
-                ) * z
+            terra::rast(
+                system.file(
+                    "ex",
+                    "elev.tif",
+                    package = "terra"
+                )
+            ) * z
         }
         list(
             geotargets::tar_terra_sds(
@@ -65,4 +65,48 @@ targets::tar_test("tar_terra_sds() works", {
     x <- targets::tar_read(raster_elevs)
     expect_s4_class(x, "SpatRasterDataset")
     expect_snapshot(x)
+})
+
+#difficult to test for this warning from tar_terra_sprc() because it doesn't end up in tar_meta() (bug?)
+test_that("wrapped write function doesn't print warning", {
+    f <- system.file("ex/elev.tif", package="terra")
+    r <- terra::rast(f)
+    object <- terra::sprc(r, terra::project(r, "+proj=igh"))
+    path <- withr::local_tempfile()
+    terra::writeRaster(
+        x = object[1],
+        filename = path,
+        filetype = "GTiff",
+        overwrite = TRUE,
+        gdal = ""
+    )
+
+    expect_warning(
+        terra::writeRaster(
+            x = object[2],
+            filename = path,
+            filetype = "GTiff",
+            overwrite = FALSE,
+            gdal = "APPEND_SUBDATASET=YES"
+        )
+    )
+
+    expect_no_warning(
+        withCallingHandlers(
+            warning = function(cnd) {
+                if (grepl("\\[rast\\] skipped sub-datasets", cnd$message)) {
+                    rlang::cnd_muffle(cnd)
+                } else {
+                    warning(cnd$message)
+                }
+            },
+            terra::writeRaster(
+                x = object[2],
+                filename = path,
+                filetype = "GTiff",
+                overwrite = FALSE,
+                gdal = "APPEND_SUBDATASET=YES"
+            )
+        )
+    )
 })

--- a/tests/testthat/test-tar-terra-sprc.R
+++ b/tests/testthat/test-tar-terra-sprc.R
@@ -67,7 +67,12 @@ targets::tar_test("tar_terra_sds() works", {
     expect_snapshot(x)
 })
 
-#difficult to test for this warning from tar_terra_sprc() because it doesn't end up in tar_meta() (bug?)
+#difficult to test for this warning from tar_terra_sprc() because it doesn't end
+#up in tar_meta() in current version of `targets`.  Added in dev version:
+#https://github.com/ropensci/targets/discussions/1345#discussioncomment-10908585.
+#Once this is released, this test can be replaced with a targets pipeline and a
+#check on `tar_meta(target, warnings)`
+
 test_that("wrapped write function doesn't print warning", {
     f <- system.file("ex/elev.tif", package="terra")
     r <- terra::rast(f)


### PR DESCRIPTION
Addresses #92 by wrapping the write function in `withCallingHandlers()` to capture the uninformative warning `[rast] skipped sub-datasets ...`.  The warning originates from `terra::writeRaster()` when it is used to write a subdataset because the return value of `writeRaster()` is `rast(<file>)` and that file can't be correctly read by `rast()` if it has subdatasets with different projections.

This was difficult to add a test for since warnings from write functions apparently don't bubble up to the output of `tar_meta()`.  I added a test for a version of the write function instead. 