### PR TITLE
custom documentation for name, command, and pattern params

### DIFF
--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -5,13 +5,13 @@
 #'
 #' @param gdal_raster_driver character, length 1; set the driver used for raster
 #'   data in target store (default: `"GTiff"`). Options for driver names can be
-#'   found here: <https://gdal.org/drivers/raster/index.html>
+#'   found here: <https://gdal.org/drivers/raster/index.html>.
 #' @param gdal_raster_creation_options character; set the GDAL creation options
 #'   used when writing raster files to target store (default: `""`). You may
 #'   specify multiple values e.g. `c("COMPRESS=DEFLATE", "TFW=YES")`. Each GDAL
 #'   driver supports a unique set of creation options. For example, with the
 #'   default `"GTiff"` driver:
-#'   <https://gdal.org/drivers/raster/gtiff.html#creation-options>
+#'   <https://gdal.org/drivers/raster/gtiff.html#creation-options>.
 #' @param gdal_vector_driver character, length 1; set the file type used for
 #' vector data in target store (default: `"GeoJSON"`).
 #' @param gdal_vector_creation_options character; set the GDAL layer creation

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -1,7 +1,12 @@
 #' Create a stars _stars_ Target
 #'
 #' Provides a target format for stars objects.
-#'
+#' @param name Symbol, name of the target. A target
+#'   name must be a valid name for a symbol in R, and it
+#'   must not start with a dot. See [targets::tar_target()] for more information.
+#' @param command R code to run the target.
+#' @param pattern Code to define a dynamic branching pattern for a target. See
+#'   [targets::tar_target()] for more information
 #' @param driver character. File format expressed as GDAL driver names passed to [stars::write_stars()]. See [sf::st_drivers()].
 #' @param options character. GDAL driver specific datasource creation options passed to [stars::write_stars()]
 #' @param proxy logical. Passed to [stars::read_stars()]. If `TRUE` the target will be read as an object of class `stars_proxy`. Otherwise, the object is class `stars`.
@@ -14,7 +19,7 @@
 #' @note The `iteration` argument is unavailable because it is hard-coded to
 #'   `"list"`, the only option that works currently.
 #'
-#' @seealso [targets::tar_target_raw()]
+#' @seealso [targets::tar_target()]
 #' @export
 #' @examplesIf rlang::is_installed("stars")
 #' if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -6,13 +6,13 @@
 #'   must not start with a dot. See [targets::tar_target()] for more information.
 #' @param command R code to run the target.
 #' @param pattern Code to define a dynamic branching pattern for a target. See
-#'   [targets::tar_target()] for more information
+#'   [targets::tar_target()] for more information.
 #' @param driver character. File format expressed as GDAL driver names passed to [stars::write_stars()]. See [sf::st_drivers()].
-#' @param options character. GDAL driver specific datasource creation options passed to [stars::write_stars()]
+#' @param options character. GDAL driver specific datasource creation options passed to [stars::write_stars()].
 #' @param proxy logical. Passed to [stars::read_stars()]. If `TRUE` the target will be read as an object of class `stars_proxy`. Otherwise, the object is class `stars`.
 #' @param mdim logical. Use the [Multidimensional Raster Data Model](https://gdal.org/user/multidim_raster_data_model.html) via [stars::write_mdim()]? Default: `FALSE`. Only supported for some drivers, e.g. `"netCDF"` or `"Zarr"`.
 #' @param ncdf logical. Use the NetCDF library directly to read data via [stars::read_ncdf()]? Default: `FALSE`. Only supported for `driver="netCDF"`.
-#' @param ... Additional arguments not yet used
+#' @param ... Additional arguments not yet used.
 #'
 #' @inheritParams targets::tar_target
 #'

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -2,9 +2,25 @@
 #'
 #' Provides a target format for [terra::SpatRaster-class] objects.
 #'
+#' @details
+#' [terra::SpatRaster-class] objects do not contain raster data directly—they
+#' contain a C++ pointer to memory where the data is stored.  As a result, these
+#' objects are not portable between R sessions without special handling, which
+#' causes problems when including them in `targets` pipelines with
+#' `tar_target()`. `tar_terra_rast()` handles this issue by writing and reading
+#' the target as a geospatial file (specified by `filetype`) rather than saving
+#' the `SpatRaster` object itself.
+#'
+#'
+#' @param name Symbol, name of the target. A target
+#'   name must be a valid name for a symbol in R, and it
+#'   must not start with a dot. See [targets::tar_target()] for more information.
+#' @param command R code to run the target.
+#' @param pattern Code to define a dynamic branching pattern for a target. See
+#'   [targets::tar_target()] for more information
 #' @param filetype character. File format expressed as GDAL driver names passed
 #'   to [terra::writeRaster()]
-#' @param gdal character. GDAL driver specific datasource creation options
+#' @param gdal character. GDAL driver specific data source creation options
 #'   passed to [terra::writeRaster()]
 #' @param ... Additional arguments not yet used
 #'
@@ -15,7 +31,7 @@
 #'
 #' @returns target class "tar_stem" for use in a target pipeline
 #' @importFrom rlang %||% arg_match0
-#' @seealso [targets::tar_target_raw()]
+#' @seealso [targets::tar_target()]
 #' @export
 #' @examples
 #' if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -17,12 +17,12 @@
 #'   must not start with a dot. See [targets::tar_target()] for more information.
 #' @param command R code to run the target.
 #' @param pattern Code to define a dynamic branching pattern for a target. See
-#'   [targets::tar_target()] for more information
+#'   [targets::tar_target()] for more information.
 #' @param filetype character. File format expressed as GDAL driver names passed
-#'   to [terra::writeRaster()]
+#'   to [terra::writeRaster()].
 #' @param gdal character. GDAL driver specific data source creation options
-#'   passed to [terra::writeRaster()]
-#' @param ... Additional arguments not yet used
+#'   passed to [terra::writeRaster()].
+#' @param ... Additional arguments not yet used.
 #'
 #' @inheritParams targets::tar_target
 #'

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -8,12 +8,12 @@
 #'   must not start with a dot. See [targets::tar_target()] for more information.
 #' @param command R code to run the target.
 #' @param pattern Code to define a dynamic branching pattern for a target. See
-#'   [targets::tar_target()] for more information
+#'   [targets::tar_target()] for more information.
 #' @param filetype character. File format expressed as GDAL driver names passed
-#'   to [terra::writeRaster()]
-#' @param gdal character. GDAL driver specific datasource creation options
+#'   to [terra::writeRaster()].
+#' @param gdal character. GDAL driver specific datasource creation options.
 #'   passed to [terra::writeRaster()]
-#' @param ... Additional arguments not yet used
+#' @param ... Additional arguments not yet used.
 #'
 #' @inheritParams targets::tar_target
 #'
@@ -135,12 +135,12 @@ tar_terra_sprc <- function(name,
 #'   must not start with a dot. See [targets::tar_target()] for more information.
 #' @param command R code to run the target.
 #' @param pattern Code to define a dynamic branching pattern for a target. See
-#'   [targets::tar_target()] for more information
+#'   [targets::tar_target()] for more information.
 #' @param filetype character. File format expressed as GDAL driver names passed
-#'   to [terra::writeRaster()]
-#' @param gdal character. GDAL driver specific datasource creation options
+#'   to [terra::writeRaster()].
+#' @param gdal character. GDAL driver specific datasource creation options.
 #'   passed to [terra::writeRaster()]
-#' @param ... Additional arguments not yet used
+#' @param ... Additional arguments not yet used.
 #'
 #' @inheritParams targets::tar_target
 #'

--- a/R/tar-terra-sprc.R
+++ b/R/tar-terra-sprc.R
@@ -3,6 +3,12 @@
 #' Provides a target format for [terra::SpatRasterCollection] objects,
 #'   which have no restriction in the extent or other geometric parameters.
 #'
+#' @param name Symbol, name of the target. A target
+#'   name must be a valid name for a symbol in R, and it
+#'   must not start with a dot. See [targets::tar_target()] for more information.
+#' @param command R code to run the target.
+#' @param pattern Code to define a dynamic branching pattern for a target. See
+#'   [targets::tar_target()] for more information
 #' @param filetype character. File format expressed as GDAL driver names passed
 #'   to [terra::writeRaster()]
 #' @param gdal character. GDAL driver specific datasource creation options
@@ -124,6 +130,12 @@ tar_terra_sprc <- function(name,
 #' Provides a target format for [terra::SpatRasterDataset] objects,
 #'   which hold sub-datasets, each a `SpatRaster` that can have multiple layers.
 #'
+#' @param name Symbol, name of the target. A target
+#'   name must be a valid name for a symbol in R, and it
+#'   must not start with a dot. See [targets::tar_target()] for more information.
+#' @param command R code to run the target.
+#' @param pattern Code to define a dynamic branching pattern for a target. See
+#'   [targets::tar_target()] for more information
 #' @param filetype character. File format expressed as GDAL driver names passed
 #'   to [terra::writeRaster()]
 #' @param gdal character. GDAL driver specific datasource creation options

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -2,6 +2,21 @@
 #'
 #' Provides a target format for [terra::SpatVector-class] objects.
 #'
+#' @details
+#' [terra::SpatVector-class] objects do not contain vector data directly—they
+#' contain a C++ pointer to memory where the data is stored.  As a result, these
+#' objects are not portable between R sessions without special handling, which
+#' causes problems when including them in `targets` pipelines with
+#' `tar_target()`. `tar_terra_rast()` handles this issue by writing and reading
+#' the target as a geospatial file (specified by `filetype`) rather than saving
+#' the `SpatVector` object itself.
+#'
+#' @param name Symbol, name of the target. A target
+#'   name must be a valid name for a symbol in R, and it
+#'   must not start with a dot. See [targets::tar_target()] for more information.
+#' @param command R code to run the target.
+#' @param pattern Code to define a dynamic branching pattern for a target. See
+#'   [targets::tar_target()] for more information
 #' @param filetype character. File format expressed as GDAL driver names passed
 #'   to [terra::writeVector()]. See 'Note' for more details
 #' @param gdal character. GDAL driver specific datasource creation options

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -16,12 +16,12 @@
 #'   must not start with a dot. See [targets::tar_target()] for more information.
 #' @param command R code to run the target.
 #' @param pattern Code to define a dynamic branching pattern for a target. See
-#'   [targets::tar_target()] for more information
+#'   [targets::tar_target()] for more information.
 #' @param filetype character. File format expressed as GDAL driver names passed
-#'   to [terra::writeVector()]. See 'Note' for more details
+#'   to [terra::writeVector()]. See 'Note' for more details.
 #' @param gdal character. GDAL driver specific datasource creation options
 #'   passed to [terra::writeVector()].
-#' @param ... Additional arguments not yet used
+#' @param ... Additional arguments not yet used.
 #' @inheritParams targets::tar_target
 #'
 #' @note The `iteration` argument is unavailable because it is hard-coded to

--- a/R/tar_terra_tiles.R
+++ b/R/tar_terra_tiles.R
@@ -2,8 +2,10 @@
 #'
 #' This target factory is useful when a raster is too large or too high
 #' resolution to work on in-memory. It can instead be split into tiles that can
-#' be iterated over, potentially using parallel workers.
-#'
+#' be iterated over using dynamic branching.
+#' @param name Symbol, name of the target. A target
+#'   name must be a valid name for a symbol in R, and it
+#'   must not start with a dot. See [targets::tar_target()] for more information.
 #' @param raster a `SpatRaster` object to be split into tiles
 #' @param tile_fun a helper function that returns a list of numeric vectors such as [tile_grid] or [tile_blocksize] specified in one of the following ways:
 #'  - A named function, e.g. `tile_blocksize` or `"tile_blocksize"`
@@ -24,7 +26,7 @@
 #'   extents and a downstream pattern that maps over these extents to create a
 #'   list of SpatRaster objects.
 #'
-#' @seealso [tile_grid()], [tile_blocksize()], [tar_terra_rast()]
+#' @seealso [tile_n()], [tile_grid()], [tile_blocksize()], [tar_terra_rast()]
 #' @export
 #'
 #' @examples

--- a/R/tar_terra_tiles.R
+++ b/R/tar_terra_tiles.R
@@ -6,16 +6,16 @@
 #' @param name Symbol, name of the target. A target
 #'   name must be a valid name for a symbol in R, and it
 #'   must not start with a dot. See [targets::tar_target()] for more information.
-#' @param raster a `SpatRaster` object to be split into tiles
+#' @param raster a `SpatRaster` object to be split into tiles.
 #' @param tile_fun a helper function that returns a list of numeric vectors such as [tile_grid] or [tile_blocksize] specified in one of the following ways:
-#'  - A named function, e.g. `tile_blocksize` or `"tile_blocksize"`
-#'  - An anonymous function, e.g. `\(x) tile_grid(x, nrow = 2, ncol = 2)`
+#'  - A named function, e.g. `tile_blocksize` or `"tile_blocksize"`.
+#'  - An anonymous function, e.g. `\(x) tile_grid(x, nrow = 2, ncol = 2)`.
 #' @param filetype character. File format expressed as GDAL driver names passed
-#'   to [terra::makeTiles()]
+#'   to [terra::makeTiles()].
 #' @param gdal character. GDAL driver specific datasource creation options
-#'   passed to [terra::makeTiles()]
+#'   passed to [terra::makeTiles()].
 #'
-#' @param ... additional arguments not yet used
+#' @param ... additional arguments not yet used.
 #' @inheritParams targets::tar_target
 #' @author Eric Scott
 #'
@@ -203,8 +203,8 @@ tar_terra_tiles_raw <- function(
 #' which, rather than modifying the SpatRaster in place, returns a new
 #' SpatRaster leaving the original unchanged.
 #'
-#' @param raster a SpatRaster object
-#' @param window a SpatExtent object defining the area of interest
+#' @param raster a SpatRaster object.
+#' @param window a SpatExtent object defining the area of interest.
 #'
 #' @note While this may have general use, it was created primarily for use
 #'   within [tar_terra_tiles()].
@@ -224,8 +224,6 @@ set_window <- function(raster, window) {
     raster_out
 }
 
-
-
 #' Helper functions to create tiles
 #'
 #' Wrappers around [terra::getTileExtents()] that return a list of named numeric
@@ -242,12 +240,12 @@ set_window <- function(raster, window) {
 #' columns to split the raster into.  E.g. nrow = 2 and ncol = 2 would create 4
 #' tiles (because it specifies a 2x2 matrix, which has 4 elements).
 #'
-#' @param raster a SpatRaster object
-#' @param ncol integer; number of columns to split the SpatRaster into
-#' @param nrow integer; number of rows to split the SpatRaster into
-#' @param n integer; total number of tiles to split the SpatRaster into
-#' @param n_blocks_row integer; multiple of blocksize to include in each tile vertically
-#' @param n_blocks_col integer; multiple of blocksize to include in each tile horizontally
+#' @param raster a SpatRaster object.
+#' @param ncol integer; number of columns to split the SpatRaster into.
+#' @param nrow integer; number of rows to split the SpatRaster into.
+#' @param n integer; total number of tiles to split the SpatRaster into.
+#' @param n_blocks_row integer; multiple of blocksize to include in each tile vertically.
+#' @param n_blocks_col integer; multiple of blocksize to include in each tile horizontally.
 #'
 #' @author Eric Scott
 #' @return list of named numeric vectors with xmin, xmax, ymin, and ymax values

--- a/man/geotargets-options.Rd
+++ b/man/geotargets-options.Rd
@@ -17,14 +17,14 @@ geotargets_option_get(name)
 \arguments{
 \item{gdal_raster_driver}{character, length 1; set the driver used for raster
 data in target store (default: \code{"GTiff"}). Options for driver names can be
-found here: \url{https://gdal.org/drivers/raster/index.html}}
+found here: \url{https://gdal.org/drivers/raster/index.html}.}
 
 \item{gdal_raster_creation_options}{character; set the GDAL creation options
 used when writing raster files to target store (default: \code{""}). You may
 specify multiple values e.g. \code{c("COMPRESS=DEFLATE", "TFW=YES")}. Each GDAL
 driver supports a unique set of creation options. For example, with the
 default \code{"GTiff"} driver:
-\url{https://gdal.org/drivers/raster/gtiff.html#creation-options}}
+\url{https://gdal.org/drivers/raster/gtiff.html#creation-options}.}
 
 \item{gdal_vector_driver}{character, length 1; set the file type used for
 vector data in target store (default: \code{"GeoJSON"}).}

--- a/man/set_window.Rd
+++ b/man/set_window.Rd
@@ -7,9 +7,9 @@
 set_window(raster, window)
 }
 \arguments{
-\item{raster}{a SpatRaster object}
+\item{raster}{a SpatRaster object.}
 
-\item{window}{a SpatExtent object defining the area of interest}
+\item{window}{a SpatExtent object defining the area of interest.}
 }
 \description{
 Create a new SpatRaster object as specified by a window (area of interest)

--- a/man/tar_stars.Rd
+++ b/man/tar_stars.Rd
@@ -57,44 +57,14 @@ tar_stars_proxy(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
-\code{tar_target(name = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
-\code{tar_target_raw(name = "data")}.
+\item{name}{Symbol, name of the target. A target
+name must be a valid name for a symbol in R, and it
+must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
-A target name must be a valid name for a symbol in R, and it
-must not start with a dot. Subsequent targets
-can refer to this name symbolically to induce a dependency relationship:
-e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
-target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}. In addition, a target's
-name determines its random number generator seed. In this way,
-each target runs with a reproducible seed so someone else
-running the same pipeline should get the same results,
-and no two targets in the same pipeline share the same seed.
-(Even dynamic branches have different names and thus different seeds.)
-You can recover the seed of a completed target
-with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
-on the result to locally recreate the target's initial RNG state.}
+\item{command}{R code to run the target.}
 
-\item{command}{R code to run the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
-\code{tar_target(command = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(command = quote(data))}.}
-
-\item{pattern}{Code to define a dynamic branching branching for a target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
-\code{tar_target(pattern = map(data))}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(pattern = quote(map(data)))}.
-
-To demonstrate dynamic branching patterns, suppose we have
-a pipeline with numeric vector targets \code{x} and \code{y}. Then,
-\code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
-branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
-and so on. See the user manual for details.}
+\item{pattern}{Code to define a dynamic branching pattern for a target. See
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
 
 \item{proxy}{logical. Passed to \code{\link[stars:read_stars]{stars::read_stars()}}. If \code{TRUE} the target will be read as an object of class \code{stars_proxy}. Otherwise, the object is class \code{stars}.}
 
@@ -192,8 +162,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -296,5 +275,5 @@ if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\code{\link[targets:tar_target]{targets::tar_target_raw()}}
+\code{\link[targets:tar_target]{targets::tar_target()}}
 }

--- a/man/tar_stars.Rd
+++ b/man/tar_stars.Rd
@@ -64,7 +64,7 @@ must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_targ
 \item{command}{R code to run the target.}
 
 \item{pattern}{Code to define a dynamic branching pattern for a target. See
-\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
 \item{proxy}{logical. Passed to \code{\link[stars:read_stars]{stars::read_stars()}}. If \code{TRUE} the target will be read as an object of class \code{stars_proxy}. Otherwise, the object is class \code{stars}.}
 
@@ -74,9 +74,9 @@ must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_targ
 
 \item{driver}{character. File format expressed as GDAL driver names passed to \code{\link[stars:write_stars]{stars::write_stars()}}. See \code{\link[sf:st_drivers]{sf::st_drivers()}}.}
 
-\item{options}{character. GDAL driver specific datasource creation options passed to \code{\link[stars:write_stars]{stars::write_stars()}}}
+\item{options}{character. GDAL driver specific datasource creation options passed to \code{\link[stars:write_stars]{stars::write_stars()}}.}
 
-\item{...}{Additional arguments not yet used}
+\item{...}{Additional arguments not yet used.}
 
 \item{tidy_eval}{Logical, whether to enable tidy evaluation
 when interpreting \code{command} and \code{pattern}. If \code{TRUE}, you can use the
@@ -162,17 +162,8 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
-just before the target runs,
-\code{FALSE} to omit garbage collection.
-In the case of high-performance computing,
-\code{gc()} runs both locally and on the parallel worker.
-All this garbage collection is skipped if the actual target
-is skipped in the pipeline.
-Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
-\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
-converted \code{FALSE}. For example, \code{garbage_collection = 2}
-is equivalent to \code{garbage_collection = FALSE}.}
+\item{garbage_collection}{Logical, whether to run \code{base::gc()}
+just before the target runs.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tar_terra_rast.Rd
+++ b/man/tar_terra_rast.Rd
@@ -35,15 +35,15 @@ must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_targ
 \item{command}{R code to run the target.}
 
 \item{pattern}{Code to define a dynamic branching pattern for a target. See
-\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
-to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
+to \code{\link[terra:writeRaster]{terra::writeRaster()}}.}
 
 \item{gdal}{character. GDAL driver specific data source creation options
-passed to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
+passed to \code{\link[terra:writeRaster]{terra::writeRaster()}}.}
 
-\item{...}{Additional arguments not yet used}
+\item{...}{Additional arguments not yet used.}
 
 \item{tidy_eval}{Logical, whether to enable tidy evaluation
 when interpreting \code{command} and \code{pattern}. If \code{TRUE}, you can use the
@@ -129,17 +129,8 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
-just before the target runs,
-\code{FALSE} to omit garbage collection.
-In the case of high-performance computing,
-\code{gc()} runs both locally and on the parallel worker.
-All this garbage collection is skipped if the actual target
-is skipped in the pipeline.
-Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
-\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
-converted \code{FALSE}. For example, \code{garbage_collection = 2}
-is equivalent to \code{garbage_collection = FALSE}.}
+\item{garbage_collection}{Logical, whether to run \code{base::gc()}
+just before the target runs.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tar_terra_rast.Rd
+++ b/man/tar_terra_rast.Rd
@@ -28,49 +28,19 @@ tar_terra_rast(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
-\code{tar_target(name = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
-\code{tar_target_raw(name = "data")}.
+\item{name}{Symbol, name of the target. A target
+name must be a valid name for a symbol in R, and it
+must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
-A target name must be a valid name for a symbol in R, and it
-must not start with a dot. Subsequent targets
-can refer to this name symbolically to induce a dependency relationship:
-e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
-target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}. In addition, a target's
-name determines its random number generator seed. In this way,
-each target runs with a reproducible seed so someone else
-running the same pipeline should get the same results,
-and no two targets in the same pipeline share the same seed.
-(Even dynamic branches have different names and thus different seeds.)
-You can recover the seed of a completed target
-with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
-on the result to locally recreate the target's initial RNG state.}
+\item{command}{R code to run the target.}
 
-\item{command}{R code to run the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
-\code{tar_target(command = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(command = quote(data))}.}
-
-\item{pattern}{Code to define a dynamic branching branching for a target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
-\code{tar_target(pattern = map(data))}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(pattern = quote(map(data)))}.
-
-To demonstrate dynamic branching patterns, suppose we have
-a pipeline with numeric vector targets \code{x} and \code{y}. Then,
-\code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
-branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
-and so on. See the user manual for details.}
+\item{pattern}{Code to define a dynamic branching pattern for a target. See
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
 to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
 
-\item{gdal}{character. GDAL driver specific datasource creation options
+\item{gdal}{character. GDAL driver specific data source creation options
 passed to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
 
 \item{...}{Additional arguments not yet used}
@@ -159,8 +129,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -242,6 +221,15 @@ target class "tar_stem" for use in a target pipeline
 \description{
 Provides a target format for \link[terra:SpatRaster-class]{terra::SpatRaster} objects.
 }
+\details{
+\link[terra:SpatRaster-class]{terra::SpatRaster} objects do not contain raster data directly—they
+contain a C++ pointer to memory where the data is stored.  As a result, these
+objects are not portable between R sessions without special handling, which
+causes problems when including them in \code{targets} pipelines with
+\code{tar_target()}. \code{tar_terra_rast()} handles this issue by writing and reading
+the target as a geospatial file (specified by \code{filetype}) rather than saving
+the \code{SpatRaster} object itself.
+}
 \note{
 The \code{iteration} argument is unavailable because it is hard-coded to
 \code{"list"}, the only option that works currently.
@@ -264,5 +252,5 @@ if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 }
 }
 \seealso{
-\code{\link[targets:tar_target]{targets::tar_target_raw()}}
+\code{\link[targets:tar_target]{targets::tar_target()}}
 }

--- a/man/tar_terra_sds.Rd
+++ b/man/tar_terra_sds.Rd
@@ -35,15 +35,15 @@ must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_targ
 \item{command}{R code to run the target.}
 
 \item{pattern}{Code to define a dynamic branching pattern for a target. See
-\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
-to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
+to \code{\link[terra:writeRaster]{terra::writeRaster()}}.}
 
-\item{gdal}{character. GDAL driver specific datasource creation options
+\item{gdal}{character. GDAL driver specific datasource creation options.
 passed to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
 
-\item{...}{Additional arguments not yet used}
+\item{...}{Additional arguments not yet used.}
 
 \item{tidy_eval}{Logical, whether to enable tidy evaluation
 when interpreting \code{command} and \code{pattern}. If \code{TRUE}, you can use the
@@ -129,17 +129,8 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
-just before the target runs,
-\code{FALSE} to omit garbage collection.
-In the case of high-performance computing,
-\code{gc()} runs both locally and on the parallel worker.
-All this garbage collection is skipped if the actual target
-is skipped in the pipeline.
-Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
-\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
-converted \code{FALSE}. For example, \code{garbage_collection = 2}
-is equivalent to \code{garbage_collection = FALSE}.}
+\item{garbage_collection}{Logical, whether to run \code{base::gc()}
+just before the target runs.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tar_terra_sds.Rd
+++ b/man/tar_terra_sds.Rd
@@ -28,44 +28,14 @@ tar_terra_sds(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
-\code{tar_target(name = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
-\code{tar_target_raw(name = "data")}.
+\item{name}{Symbol, name of the target. A target
+name must be a valid name for a symbol in R, and it
+must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
-A target name must be a valid name for a symbol in R, and it
-must not start with a dot. Subsequent targets
-can refer to this name symbolically to induce a dependency relationship:
-e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
-target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}. In addition, a target's
-name determines its random number generator seed. In this way,
-each target runs with a reproducible seed so someone else
-running the same pipeline should get the same results,
-and no two targets in the same pipeline share the same seed.
-(Even dynamic branches have different names and thus different seeds.)
-You can recover the seed of a completed target
-with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
-on the result to locally recreate the target's initial RNG state.}
+\item{command}{R code to run the target.}
 
-\item{command}{R code to run the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
-\code{tar_target(command = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(command = quote(data))}.}
-
-\item{pattern}{Code to define a dynamic branching branching for a target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
-\code{tar_target(pattern = map(data))}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(pattern = quote(map(data)))}.
-
-To demonstrate dynamic branching patterns, suppose we have
-a pipeline with numeric vector targets \code{x} and \code{y}. Then,
-\code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
-branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
-and so on. See the user manual for details.}
+\item{pattern}{Code to define a dynamic branching pattern for a target. See
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
 to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
@@ -159,8 +129,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tar_terra_sprc.Rd
+++ b/man/tar_terra_sprc.Rd
@@ -35,15 +35,15 @@ must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_targ
 \item{command}{R code to run the target.}
 
 \item{pattern}{Code to define a dynamic branching pattern for a target. See
-\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
-to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
+to \code{\link[terra:writeRaster]{terra::writeRaster()}}.}
 
-\item{gdal}{character. GDAL driver specific datasource creation options
+\item{gdal}{character. GDAL driver specific datasource creation options.
 passed to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
 
-\item{...}{Additional arguments not yet used}
+\item{...}{Additional arguments not yet used.}
 
 \item{tidy_eval}{Logical, whether to enable tidy evaluation
 when interpreting \code{command} and \code{pattern}. If \code{TRUE}, you can use the
@@ -129,17 +129,8 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
-just before the target runs,
-\code{FALSE} to omit garbage collection.
-In the case of high-performance computing,
-\code{gc()} runs both locally and on the parallel worker.
-All this garbage collection is skipped if the actual target
-is skipped in the pipeline.
-Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
-\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
-converted \code{FALSE}. For example, \code{garbage_collection = 2}
-is equivalent to \code{garbage_collection = FALSE}.}
+\item{garbage_collection}{Logical, whether to run \code{base::gc()}
+just before the target runs.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tar_terra_sprc.Rd
+++ b/man/tar_terra_sprc.Rd
@@ -28,44 +28,14 @@ tar_terra_sprc(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
-\code{tar_target(name = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
-\code{tar_target_raw(name = "data")}.
+\item{name}{Symbol, name of the target. A target
+name must be a valid name for a symbol in R, and it
+must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
-A target name must be a valid name for a symbol in R, and it
-must not start with a dot. Subsequent targets
-can refer to this name symbolically to induce a dependency relationship:
-e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
-target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}. In addition, a target's
-name determines its random number generator seed. In this way,
-each target runs with a reproducible seed so someone else
-running the same pipeline should get the same results,
-and no two targets in the same pipeline share the same seed.
-(Even dynamic branches have different names and thus different seeds.)
-You can recover the seed of a completed target
-with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
-on the result to locally recreate the target's initial RNG state.}
+\item{command}{R code to run the target.}
 
-\item{command}{R code to run the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
-\code{tar_target(command = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(command = quote(data))}.}
-
-\item{pattern}{Code to define a dynamic branching branching for a target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
-\code{tar_target(pattern = map(data))}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(pattern = quote(map(data)))}.
-
-To demonstrate dynamic branching patterns, suppose we have
-a pipeline with numeric vector targets \code{x} and \code{y}. Then,
-\code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
-branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
-and so on. See the user manual for details.}
+\item{pattern}{Code to define a dynamic branching pattern for a target. See
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
 to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
@@ -159,8 +129,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tar_terra_tiles.Rd
+++ b/man/tar_terra_tiles.Rd
@@ -27,26 +27,9 @@ tar_terra_tiles(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
-\code{tar_target(name = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
-\code{tar_target_raw(name = "data")}.
-
-A target name must be a valid name for a symbol in R, and it
-must not start with a dot. Subsequent targets
-can refer to this name symbolically to induce a dependency relationship:
-e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
-target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}. In addition, a target's
-name determines its random number generator seed. In this way,
-each target runs with a reproducible seed so someone else
-running the same pipeline should get the same results,
-and no two targets in the same pipeline share the same seed.
-(Even dynamic branches have different names and thus different seeds.)
-You can recover the seed of a completed target
-with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
-on the result to locally recreate the target's initial RNG state.}
+\item{name}{Symbol, name of the target. A target
+name must be a valid name for a symbol in R, and it
+must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
 \item{raster}{a \code{SpatRaster} object to be split into tiles}
 
@@ -143,8 +126,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -228,7 +220,7 @@ list of SpatRaster objects.
 \description{
 This target factory is useful when a raster is too large or too high
 resolution to work on in-memory. It can instead be split into tiles that can
-be iterated over, potentially using parallel workers.
+be iterated over using dynamic branching.
 }
 \note{
 The \code{iteration} argument is unavailable because it is hard-coded to
@@ -264,7 +256,7 @@ if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 }
 }
 \seealso{
-\code{\link[=tile_grid]{tile_grid()}}, \code{\link[=tile_blocksize]{tile_blocksize()}}, \code{\link[=tar_terra_rast]{tar_terra_rast()}}
+\code{\link[=tile_n]{tile_n()}}, \code{\link[=tile_grid]{tile_grid()}}, \code{\link[=tile_blocksize]{tile_blocksize()}}, \code{\link[=tar_terra_rast]{tar_terra_rast()}}
 }
 \author{
 Eric Scott

--- a/man/tar_terra_tiles.Rd
+++ b/man/tar_terra_tiles.Rd
@@ -31,21 +31,21 @@ tar_terra_tiles(
 name must be a valid name for a symbol in R, and it
 must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
-\item{raster}{a \code{SpatRaster} object to be split into tiles}
+\item{raster}{a \code{SpatRaster} object to be split into tiles.}
 
 \item{tile_fun}{a helper function that returns a list of numeric vectors such as \link{tile_grid} or \link{tile_blocksize} specified in one of the following ways:
 \itemize{
-\item A named function, e.g. \code{tile_blocksize} or \code{"tile_blocksize"}
-\item An anonymous function, e.g. \verb{\\(x) tile_grid(x, nrow = 2, ncol = 2)}
+\item A named function, e.g. \code{tile_blocksize} or \code{"tile_blocksize"}.
+\item An anonymous function, e.g. \verb{\\(x) tile_grid(x, nrow = 2, ncol = 2)}.
 }}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
-to \code{\link[terra:makeTiles]{terra::makeTiles()}}}
+to \code{\link[terra:makeTiles]{terra::makeTiles()}}.}
 
 \item{gdal}{character. GDAL driver specific datasource creation options
-passed to \code{\link[terra:makeTiles]{terra::makeTiles()}}}
+passed to \code{\link[terra:makeTiles]{terra::makeTiles()}}.}
 
-\item{...}{additional arguments not yet used}
+\item{...}{additional arguments not yet used.}
 
 \item{packages}{Character vector of packages to load right before
 the target runs or the output data is reloaded for
@@ -126,17 +126,8 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
-just before the target runs,
-\code{FALSE} to omit garbage collection.
-In the case of high-performance computing,
-\code{gc()} runs both locally and on the parallel worker.
-All this garbage collection is skipped if the actual target
-is skipped in the pipeline.
-Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
-\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
-converted \code{FALSE}. For example, \code{garbage_collection = 2}
-is equivalent to \code{garbage_collection = FALSE}.}
+\item{garbage_collection}{Logical, whether to run \code{base::gc()}
+just before the target runs.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tar_terra_vect.Rd
+++ b/man/tar_terra_vect.Rd
@@ -28,44 +28,14 @@ tar_terra_vect(
 )
 }
 \arguments{
-\item{name}{Symbol, name of the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{name} is an unevaluated symbol, e.g.
-\code{tar_target(name = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{name} is a character string, e.g.
-\code{tar_target_raw(name = "data")}.
+\item{name}{Symbol, name of the target. A target
+name must be a valid name for a symbol in R, and it
+must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
-A target name must be a valid name for a symbol in R, and it
-must not start with a dot. Subsequent targets
-can refer to this name symbolically to induce a dependency relationship:
-e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
-target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}. In addition, a target's
-name determines its random number generator seed. In this way,
-each target runs with a reproducible seed so someone else
-running the same pipeline should get the same results,
-and no two targets in the same pipeline share the same seed.
-(Even dynamic branches have different names and thus different seeds.)
-You can recover the seed of a completed target
-with \code{tar_meta(your_target, seed)} and run \code{\link[targets:tar_seed_set]{tar_seed_set()}}
-on the result to locally recreate the target's initial RNG state.}
+\item{command}{R code to run the target.}
 
-\item{command}{R code to run the target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{command} is an unevaluated expression, e.g.
-\code{tar_target(command = data)}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(command = quote(data))}.}
-
-\item{pattern}{Code to define a dynamic branching branching for a target.
-In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
-\code{tar_target(pattern = map(data))}.
-In \code{\link[targets:tar_target_raw]{tar_target_raw()}}, \code{command} is an evaluated expression, e.g.
-\code{tar_target_raw(pattern = quote(map(data)))}.
-
-To demonstrate dynamic branching patterns, suppose we have
-a pipeline with numeric vector targets \code{x} and \code{y}. Then,
-\code{tar_target(z, x + y, pattern = map(x, y))} implicitly defines
-branches of \code{z} that each compute \code{x[1] + y[1]}, \code{x[2] + y[2]},
-and so on. See the user manual for details.}
+\item{pattern}{Code to define a dynamic branching pattern for a target. See
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
 to \code{\link[terra:writeVector]{terra::writeVector()}}. See 'Note' for more details}
@@ -159,8 +129,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -241,6 +220,15 @@ target class "tar_stem" for use in a target pipeline
 }
 \description{
 Provides a target format for \link[terra:SpatVector-class]{terra::SpatVector} objects.
+}
+\details{
+\link[terra:SpatVector-class]{terra::SpatVector} objects do not contain vector data directly—they
+contain a C++ pointer to memory where the data is stored.  As a result, these
+objects are not portable between R sessions without special handling, which
+causes problems when including them in \code{targets} pipelines with
+\code{tar_target()}. \code{tar_terra_rast()} handles this issue by writing and reading
+the target as a geospatial file (specified by \code{filetype}) rather than saving
+the \code{SpatVector} object itself.
 }
 \note{
 The \code{iteration} argument is unavailable because it is hard-coded to

--- a/man/tar_terra_vect.Rd
+++ b/man/tar_terra_vect.Rd
@@ -35,15 +35,15 @@ must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_targ
 \item{command}{R code to run the target.}
 
 \item{pattern}{Code to define a dynamic branching pattern for a target. See
-\code{\link[targets:tar_target]{targets::tar_target()}} for more information}
+\code{\link[targets:tar_target]{targets::tar_target()}} for more information.}
 
 \item{filetype}{character. File format expressed as GDAL driver names passed
-to \code{\link[terra:writeVector]{terra::writeVector()}}. See 'Note' for more details}
+to \code{\link[terra:writeVector]{terra::writeVector()}}. See 'Note' for more details.}
 
 \item{gdal}{character. GDAL driver specific datasource creation options
 passed to \code{\link[terra:writeVector]{terra::writeVector()}}.}
 
-\item{...}{Additional arguments not yet used}
+\item{...}{Additional arguments not yet used.}
 
 \item{packages}{Character vector of packages to load right before
 the target runs or the output data is reloaded for
@@ -129,17 +129,8 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
-just before the target runs,
-\code{FALSE} to omit garbage collection.
-In the case of high-performance computing,
-\code{gc()} runs both locally and on the parallel worker.
-All this garbage collection is skipped if the actual target
-is skipped in the pipeline.
-Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
-\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
-converted \code{FALSE}. For example, \code{garbage_collection = 2}
-is equivalent to \code{garbage_collection = FALSE}.}
+\item{garbage_collection}{Logical, whether to run \code{base::gc()}
+just before the target runs.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.

--- a/man/tile_helpers.Rd
+++ b/man/tile_helpers.Rd
@@ -13,17 +13,17 @@ tile_blocksize(raster, n_blocks_row = 1, n_blocks_col = 1)
 tile_n(raster, n)
 }
 \arguments{
-\item{raster}{a SpatRaster object}
+\item{raster}{a SpatRaster object.}
 
-\item{ncol}{integer; number of columns to split the SpatRaster into}
+\item{ncol}{integer; number of columns to split the SpatRaster into.}
 
-\item{nrow}{integer; number of rows to split the SpatRaster into}
+\item{nrow}{integer; number of rows to split the SpatRaster into.}
 
-\item{n_blocks_row}{integer; multiple of blocksize to include in each tile vertically}
+\item{n_blocks_row}{integer; multiple of blocksize to include in each tile vertically.}
 
-\item{n_blocks_col}{integer; multiple of blocksize to include in each tile horizontally}
+\item{n_blocks_col}{integer; multiple of blocksize to include in each tile horizontally.}
 
-\item{n}{integer; total number of tiles to split the SpatRaster into}
+\item{n}{integer; total number of tiles to split the SpatRaster into.}
 }
 \value{
 list of named numeric vectors with xmin, xmax, ymin, and ymax values


### PR DESCRIPTION
This closes #107 by adding documentation for the name, command, and pattern parameters to all `tar_*()` functions rather than relying on importing the documentation for these from `targets`