### PR TITLE
Document workaround for issues with `tile_blocksize()` (#99)

### DIFF
--- a/R/tar_terra_tiles.R
+++ b/R/tar_terra_tiles.R
@@ -7,7 +7,9 @@
 #'   name must be a valid name for a symbol in R, and it
 #'   must not start with a dot. See [targets::tar_target()] for more information.
 #' @param raster a `SpatRaster` object to be split into tiles.
-#' @param tile_fun a helper function that returns a list of numeric vectors such as [tile_grid] or [tile_blocksize] specified in one of the following ways:
+#' @param tile_fun a helper function that returns a list of numeric vectors such
+#'   as [tile_grid()], [tile_n()] or [tile_blocksize] specified in one of the
+#'   following ways:
 #'  - A named function, e.g. `tile_blocksize` or `"tile_blocksize"`.
 #'  - An anonymous function, e.g. `\(x) tile_grid(x, nrow = 2, ncol = 2)`.
 #' @param filetype character. File format expressed as GDAL driver names passed
@@ -21,6 +23,11 @@
 #'
 #' @note The `iteration` argument is unavailable because it is hard-coded to
 #'   `"list"`, the only option that works currently.
+#'
+#'   When using the [tile_blocksize()] helper function, you may need to set
+#'   `memory = "transient"` on the upstream target provided to the `raster`
+#'   argument of `tar_terra_tiles()`.  More details are in the help file for
+#'   [tile_blocksize()].
 #'
 #' @return a list of two targets: an upstream target that creates a list of
 #'   extents and a downstream pattern that maps over these extents to create a
@@ -231,21 +238,31 @@ set_window <- function(raster, window) {
 #' While these may have general use, they are intended primarily for supplying
 #' to the `tile_fun` argument of [tar_terra_tiles()].
 #'
-#' `tile_blocksize()` creates extents using the raster's native blocksize (see
+#' `tile_blocksize()` creates extents using the raster's native block size (see
 #' [terra::fileBlocksize()]), which should be more memory efficient. Create
 #' tiles with multiples of the raster's blocksize with `n_blocks_row` and
 #' `n_blocks_col`. We strongly suggest the user explore how many tiles are
 #' created by `tile_blocksize()` before creating a dynamically branched target
-#' using this helper. `tile_grid()` allows specification of a number of rows and
+#' using this helper. Note that block size is a property of *files* and does not
+#' apply to in-memory `SpatRaster`s. Therefore, if you want to use this helper
+#' in [tar_terra_tiles()] you may need to ensure the upstream target provided to
+#' the `raster` argument is not in memory by setting `memory = "transient"`.
+#'
+#' `tile_grid()` allows specification of a number of rows and
 #' columns to split the raster into.  E.g. nrow = 2 and ncol = 2 would create 4
 #' tiles (because it specifies a 2x2 matrix, which has 4 elements).
+#'
+#' `tile_n()` creates (about) `n` tiles and prints the number of rows, columns,
+#' and total tiles created.
 #'
 #' @param raster a SpatRaster object.
 #' @param ncol integer; number of columns to split the SpatRaster into.
 #' @param nrow integer; number of rows to split the SpatRaster into.
 #' @param n integer; total number of tiles to split the SpatRaster into.
-#' @param n_blocks_row integer; multiple of blocksize to include in each tile vertically.
-#' @param n_blocks_col integer; multiple of blocksize to include in each tile horizontally.
+#' @param n_blocks_row integer; multiple of blocksize to include in each tile
+#'   vertically.
+#' @param n_blocks_col integer; multiple of blocksize to include in each tile
+#'   horizontally.
 #'
 #' @author Eric Scott
 #' @return list of named numeric vectors with xmin, xmax, ymin, and ymax values

--- a/man/tar_stars.Rd
+++ b/man/tar_stars.Rd
@@ -123,7 +123,9 @@ stops and throws an error. Options:
 \item \code{"continue"}: the whole pipeline keeps going.
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
-up to date for the next run of the pipeline.
+up to date for the next run of the pipeline. In addition,
+as of version 1.8.0.9011, a value of \code{NULL} is given
+to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
 \item \code{"trim"}: all currently running targets stay running. A queued
@@ -142,19 +144,26 @@ to begin running.
 to learn how to debug targets using saved workspaces.)
 }}
 
-\item{memory}{Character of length 1, memory strategy.
-If \code{"persistent"}, the target stays in memory
+\item{memory}{Character of length 1, memory strategy. Possible values:
+\itemize{
+\item \code{"auto"}: new in \code{targets} version 1.8.0.9011, \code{memory = "auto"}
+is equivalent to \code{memory = "transient"} for dynamic branching
+(a non-null \code{pattern} argument) and \code{memory = "persistent"}
+for targets that do not use dynamic branching.
+\item \code{"persistent"}: the target stays in memory
 until the end of the pipeline (unless \code{storage} is \code{"worker"},
 in which case \code{targets} unloads the value from memory
 right after storing it in order to avoid sending
 copious data over a network).
-If \code{"transient"}, the target gets unloaded
+\item \code{"transient"}: the target gets unloaded
 after every new target completes.
 Either way, the target gets automatically loaded into memory
 whenever another target needs the value.
+}
+
 For cloud-based dynamic files
 (e.g. \code{format = "file"} with \code{repository = "aws"}),
-this memory strategy applies to the
+the \code{memory} option applies to the
 temporary local copy of the file:
 \code{"persistent"} means it remains until the end of the pipeline
 and is then deleted,
@@ -162,8 +171,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -184,47 +202,33 @@ functionality, alternative data storage formats,
 and other optional capabilities of \code{targets}.
 See \code{tar_resources()} for details.}
 
-\item{storage}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{storage}{Character string to control when the output of the target
+is saved to storage. Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's return value is sent back to the
 host machine and saved/uploaded locally.
 \item \code{"worker"}: the worker saves/uploads the value.
-\item \code{"none"}: almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language. If you do use it,
-then the return value of the target is totally ignored
-when the target ends, but
-each downstream target still attempts to load the data file
-(except when \code{retrieval = "none"}).
-
-If you select \code{storage = "none"}, then
-the return value of the target's command is ignored,
-and the data is not saved automatically.
-As with dynamic files (\code{format = "file"}) it is the
-responsibility of the user to write to
-the data store from inside the target.
-
-The distinguishing feature of \code{storage = "none"}
-(as opposed to \code{format = "file"})
-is that in the general case,
-downstream targets will automatically try to load the data
-from the data store as a dependency. As a corollary, \code{storage = "none"}
-is completely unnecessary if \code{format} is \code{"file"}.
+\item \code{"none"}: \code{targets} makes no attempt to save the result
+of the target to storage in the location where \code{targets}
+expects it to be. Saving to storage is the responsibility
+of the user. Use with caution.
 }}
 
-\item{retrieval}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{retrieval}{Character string to control when the current target
+loads its dependencies into memory before running.
+(Here, a "dependency" is another target upstream that the current one
+depends on.) Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's dependencies are loaded on the host machine
 and sent to the worker before the target runs.
-\item \code{"worker"}: the worker loads the targets dependencies.
-\item \code{"none"}: the dependencies are not loaded at all.
-This choice is almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language.
+\item \code{"worker"}: the worker loads the target's dependencies.
+\item \code{"none"}: \code{targets} makes no attempt to load its
+dependencies. With \code{retrieval = "none"}, loading dependencies
+is the responsibility of the user. Use with caution.
 }}
 
 \item{cue}{An optional object from \code{tar_cue()} to customize the

--- a/man/tar_terra_rast.Rd
+++ b/man/tar_terra_rast.Rd
@@ -99,7 +99,9 @@ stops and throws an error. Options:
 \item \code{"continue"}: the whole pipeline keeps going.
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
-up to date for the next run of the pipeline.
+up to date for the next run of the pipeline. In addition,
+as of version 1.8.0.9011, a value of \code{NULL} is given
+to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
 \item \code{"trim"}: all currently running targets stay running. A queued
@@ -118,19 +120,26 @@ to begin running.
 to learn how to debug targets using saved workspaces.)
 }}
 
-\item{memory}{Character of length 1, memory strategy.
-If \code{"persistent"}, the target stays in memory
+\item{memory}{Character of length 1, memory strategy. Possible values:
+\itemize{
+\item \code{"auto"}: new in \code{targets} version 1.8.0.9011, \code{memory = "auto"}
+is equivalent to \code{memory = "transient"} for dynamic branching
+(a non-null \code{pattern} argument) and \code{memory = "persistent"}
+for targets that do not use dynamic branching.
+\item \code{"persistent"}: the target stays in memory
 until the end of the pipeline (unless \code{storage} is \code{"worker"},
 in which case \code{targets} unloads the value from memory
 right after storing it in order to avoid sending
 copious data over a network).
-If \code{"transient"}, the target gets unloaded
+\item \code{"transient"}: the target gets unloaded
 after every new target completes.
 Either way, the target gets automatically loaded into memory
 whenever another target needs the value.
+}
+
 For cloud-based dynamic files
 (e.g. \code{format = "file"} with \code{repository = "aws"}),
-this memory strategy applies to the
+the \code{memory} option applies to the
 temporary local copy of the file:
 \code{"persistent"} means it remains until the end of the pipeline
 and is then deleted,
@@ -138,8 +147,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -160,47 +178,33 @@ functionality, alternative data storage formats,
 and other optional capabilities of \code{targets}.
 See \code{tar_resources()} for details.}
 
-\item{storage}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{storage}{Character string to control when the output of the target
+is saved to storage. Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's return value is sent back to the
 host machine and saved/uploaded locally.
 \item \code{"worker"}: the worker saves/uploads the value.
-\item \code{"none"}: almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language. If you do use it,
-then the return value of the target is totally ignored
-when the target ends, but
-each downstream target still attempts to load the data file
-(except when \code{retrieval = "none"}).
-
-If you select \code{storage = "none"}, then
-the return value of the target's command is ignored,
-and the data is not saved automatically.
-As with dynamic files (\code{format = "file"}) it is the
-responsibility of the user to write to
-the data store from inside the target.
-
-The distinguishing feature of \code{storage = "none"}
-(as opposed to \code{format = "file"})
-is that in the general case,
-downstream targets will automatically try to load the data
-from the data store as a dependency. As a corollary, \code{storage = "none"}
-is completely unnecessary if \code{format} is \code{"file"}.
+\item \code{"none"}: \code{targets} makes no attempt to save the result
+of the target to storage in the location where \code{targets}
+expects it to be. Saving to storage is the responsibility
+of the user. Use with caution.
 }}
 
-\item{retrieval}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{retrieval}{Character string to control when the current target
+loads its dependencies into memory before running.
+(Here, a "dependency" is another target upstream that the current one
+depends on.) Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's dependencies are loaded on the host machine
 and sent to the worker before the target runs.
-\item \code{"worker"}: the worker loads the targets dependencies.
-\item \code{"none"}: the dependencies are not loaded at all.
-This choice is almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language.
+\item \code{"worker"}: the worker loads the target's dependencies.
+\item \code{"none"}: \code{targets} makes no attempt to load its
+dependencies. With \code{retrieval = "none"}, loading dependencies
+is the responsibility of the user. Use with caution.
 }}
 
 \item{cue}{An optional object from \code{tar_cue()} to customize the

--- a/man/tar_terra_sds.Rd
+++ b/man/tar_terra_sds.Rd
@@ -90,7 +90,9 @@ stops and throws an error. Options:
 \item \code{"continue"}: the whole pipeline keeps going.
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
-up to date for the next run of the pipeline.
+up to date for the next run of the pipeline. In addition,
+as of version 1.8.0.9011, a value of \code{NULL} is given
+to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
 \item \code{"trim"}: all currently running targets stay running. A queued
@@ -109,19 +111,26 @@ to begin running.
 to learn how to debug targets using saved workspaces.)
 }}
 
-\item{memory}{Character of length 1, memory strategy.
-If \code{"persistent"}, the target stays in memory
+\item{memory}{Character of length 1, memory strategy. Possible values:
+\itemize{
+\item \code{"auto"}: new in \code{targets} version 1.8.0.9011, \code{memory = "auto"}
+is equivalent to \code{memory = "transient"} for dynamic branching
+(a non-null \code{pattern} argument) and \code{memory = "persistent"}
+for targets that do not use dynamic branching.
+\item \code{"persistent"}: the target stays in memory
 until the end of the pipeline (unless \code{storage} is \code{"worker"},
 in which case \code{targets} unloads the value from memory
 right after storing it in order to avoid sending
 copious data over a network).
-If \code{"transient"}, the target gets unloaded
+\item \code{"transient"}: the target gets unloaded
 after every new target completes.
 Either way, the target gets automatically loaded into memory
 whenever another target needs the value.
+}
+
 For cloud-based dynamic files
 (e.g. \code{format = "file"} with \code{repository = "aws"}),
-this memory strategy applies to the
+the \code{memory} option applies to the
 temporary local copy of the file:
 \code{"persistent"} means it remains until the end of the pipeline
 and is then deleted,
@@ -129,8 +138,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -151,47 +169,33 @@ functionality, alternative data storage formats,
 and other optional capabilities of \code{targets}.
 See \code{tar_resources()} for details.}
 
-\item{storage}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{storage}{Character string to control when the output of the target
+is saved to storage. Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's return value is sent back to the
 host machine and saved/uploaded locally.
 \item \code{"worker"}: the worker saves/uploads the value.
-\item \code{"none"}: almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language. If you do use it,
-then the return value of the target is totally ignored
-when the target ends, but
-each downstream target still attempts to load the data file
-(except when \code{retrieval = "none"}).
-
-If you select \code{storage = "none"}, then
-the return value of the target's command is ignored,
-and the data is not saved automatically.
-As with dynamic files (\code{format = "file"}) it is the
-responsibility of the user to write to
-the data store from inside the target.
-
-The distinguishing feature of \code{storage = "none"}
-(as opposed to \code{format = "file"})
-is that in the general case,
-downstream targets will automatically try to load the data
-from the data store as a dependency. As a corollary, \code{storage = "none"}
-is completely unnecessary if \code{format} is \code{"file"}.
+\item \code{"none"}: \code{targets} makes no attempt to save the result
+of the target to storage in the location where \code{targets}
+expects it to be. Saving to storage is the responsibility
+of the user. Use with caution.
 }}
 
-\item{retrieval}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{retrieval}{Character string to control when the current target
+loads its dependencies into memory before running.
+(Here, a "dependency" is another target upstream that the current one
+depends on.) Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's dependencies are loaded on the host machine
 and sent to the worker before the target runs.
-\item \code{"worker"}: the worker loads the targets dependencies.
-\item \code{"none"}: the dependencies are not loaded at all.
-This choice is almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language.
+\item \code{"worker"}: the worker loads the target's dependencies.
+\item \code{"none"}: \code{targets} makes no attempt to load its
+dependencies. With \code{retrieval = "none"}, loading dependencies
+is the responsibility of the user. Use with caution.
 }}
 
 \item{cue}{An optional object from \code{tar_cue()} to customize the

--- a/man/tar_terra_sprc.Rd
+++ b/man/tar_terra_sprc.Rd
@@ -90,7 +90,9 @@ stops and throws an error. Options:
 \item \code{"continue"}: the whole pipeline keeps going.
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
-up to date for the next run of the pipeline.
+up to date for the next run of the pipeline. In addition,
+as of version 1.8.0.9011, a value of \code{NULL} is given
+to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
 \item \code{"trim"}: all currently running targets stay running. A queued
@@ -109,19 +111,26 @@ to begin running.
 to learn how to debug targets using saved workspaces.)
 }}
 
-\item{memory}{Character of length 1, memory strategy.
-If \code{"persistent"}, the target stays in memory
+\item{memory}{Character of length 1, memory strategy. Possible values:
+\itemize{
+\item \code{"auto"}: new in \code{targets} version 1.8.0.9011, \code{memory = "auto"}
+is equivalent to \code{memory = "transient"} for dynamic branching
+(a non-null \code{pattern} argument) and \code{memory = "persistent"}
+for targets that do not use dynamic branching.
+\item \code{"persistent"}: the target stays in memory
 until the end of the pipeline (unless \code{storage} is \code{"worker"},
 in which case \code{targets} unloads the value from memory
 right after storing it in order to avoid sending
 copious data over a network).
-If \code{"transient"}, the target gets unloaded
+\item \code{"transient"}: the target gets unloaded
 after every new target completes.
 Either way, the target gets automatically loaded into memory
 whenever another target needs the value.
+}
+
 For cloud-based dynamic files
 (e.g. \code{format = "file"} with \code{repository = "aws"}),
-this memory strategy applies to the
+the \code{memory} option applies to the
 temporary local copy of the file:
 \code{"persistent"} means it remains until the end of the pipeline
 and is then deleted,
@@ -129,8 +138,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -151,47 +169,33 @@ functionality, alternative data storage formats,
 and other optional capabilities of \code{targets}.
 See \code{tar_resources()} for details.}
 
-\item{storage}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{storage}{Character string to control when the output of the target
+is saved to storage. Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's return value is sent back to the
 host machine and saved/uploaded locally.
 \item \code{"worker"}: the worker saves/uploads the value.
-\item \code{"none"}: almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language. If you do use it,
-then the return value of the target is totally ignored
-when the target ends, but
-each downstream target still attempts to load the data file
-(except when \code{retrieval = "none"}).
-
-If you select \code{storage = "none"}, then
-the return value of the target's command is ignored,
-and the data is not saved automatically.
-As with dynamic files (\code{format = "file"}) it is the
-responsibility of the user to write to
-the data store from inside the target.
-
-The distinguishing feature of \code{storage = "none"}
-(as opposed to \code{format = "file"})
-is that in the general case,
-downstream targets will automatically try to load the data
-from the data store as a dependency. As a corollary, \code{storage = "none"}
-is completely unnecessary if \code{format} is \code{"file"}.
+\item \code{"none"}: \code{targets} makes no attempt to save the result
+of the target to storage in the location where \code{targets}
+expects it to be. Saving to storage is the responsibility
+of the user. Use with caution.
 }}
 
-\item{retrieval}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{retrieval}{Character string to control when the current target
+loads its dependencies into memory before running.
+(Here, a "dependency" is another target upstream that the current one
+depends on.) Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's dependencies are loaded on the host machine
 and sent to the worker before the target runs.
-\item \code{"worker"}: the worker loads the targets dependencies.
-\item \code{"none"}: the dependencies are not loaded at all.
-This choice is almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language.
+\item \code{"worker"}: the worker loads the target's dependencies.
+\item \code{"none"}: \code{targets} makes no attempt to load its
+dependencies. With \code{retrieval = "none"}, loading dependencies
+is the responsibility of the user. Use with caution.
 }}
 
 \item{cue}{An optional object from \code{tar_cue()} to customize the

--- a/man/tar_terra_tiles.Rd
+++ b/man/tar_terra_tiles.Rd
@@ -33,7 +33,9 @@ must not start with a dot. See \code{\link[targets:tar_target]{targets::tar_targ
 
 \item{raster}{a \code{SpatRaster} object to be split into tiles.}
 
-\item{tile_fun}{a helper function that returns a list of numeric vectors such as \link{tile_grid} or \link{tile_blocksize} specified in one of the following ways:
+\item{tile_fun}{a helper function that returns a list of numeric vectors such
+as \code{\link[=tile_grid]{tile_grid()}}, \code{\link[=tile_n]{tile_n()}} or \link{tile_blocksize} specified in one of the
+following ways:
 \itemize{
 \item A named function, e.g. \code{tile_blocksize} or \code{"tile_blocksize"}.
 \item An anonymous function, e.g. \verb{\\(x) tile_grid(x, nrow = 2, ncol = 2)}.
@@ -87,7 +89,9 @@ stops and throws an error. Options:
 \item \code{"continue"}: the whole pipeline keeps going.
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
-up to date for the next run of the pipeline.
+up to date for the next run of the pipeline. In addition,
+as of version 1.8.0.9011, a value of \code{NULL} is given
+to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
 \item \code{"trim"}: all currently running targets stay running. A queued
@@ -106,19 +110,26 @@ to begin running.
 to learn how to debug targets using saved workspaces.)
 }}
 
-\item{memory}{Character of length 1, memory strategy.
-If \code{"persistent"}, the target stays in memory
+\item{memory}{Character of length 1, memory strategy. Possible values:
+\itemize{
+\item \code{"auto"}: new in \code{targets} version 1.8.0.9011, \code{memory = "auto"}
+is equivalent to \code{memory = "transient"} for dynamic branching
+(a non-null \code{pattern} argument) and \code{memory = "persistent"}
+for targets that do not use dynamic branching.
+\item \code{"persistent"}: the target stays in memory
 until the end of the pipeline (unless \code{storage} is \code{"worker"},
 in which case \code{targets} unloads the value from memory
 right after storing it in order to avoid sending
 copious data over a network).
-If \code{"transient"}, the target gets unloaded
+\item \code{"transient"}: the target gets unloaded
 after every new target completes.
 Either way, the target gets automatically loaded into memory
 whenever another target needs the value.
+}
+
 For cloud-based dynamic files
 (e.g. \code{format = "file"} with \code{repository = "aws"}),
-this memory strategy applies to the
+the \code{memory} option applies to the
 temporary local copy of the file:
 \code{"persistent"} means it remains until the end of the pipeline
 and is then deleted,
@@ -126,8 +137,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -148,47 +168,33 @@ functionality, alternative data storage formats,
 and other optional capabilities of \code{targets}.
 See \code{tar_resources()} for details.}
 
-\item{storage}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{storage}{Character string to control when the output of the target
+is saved to storage. Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's return value is sent back to the
 host machine and saved/uploaded locally.
 \item \code{"worker"}: the worker saves/uploads the value.
-\item \code{"none"}: almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language. If you do use it,
-then the return value of the target is totally ignored
-when the target ends, but
-each downstream target still attempts to load the data file
-(except when \code{retrieval = "none"}).
-
-If you select \code{storage = "none"}, then
-the return value of the target's command is ignored,
-and the data is not saved automatically.
-As with dynamic files (\code{format = "file"}) it is the
-responsibility of the user to write to
-the data store from inside the target.
-
-The distinguishing feature of \code{storage = "none"}
-(as opposed to \code{format = "file"})
-is that in the general case,
-downstream targets will automatically try to load the data
-from the data store as a dependency. As a corollary, \code{storage = "none"}
-is completely unnecessary if \code{format} is \code{"file"}.
+\item \code{"none"}: \code{targets} makes no attempt to save the result
+of the target to storage in the location where \code{targets}
+expects it to be. Saving to storage is the responsibility
+of the user. Use with caution.
 }}
 
-\item{retrieval}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{retrieval}{Character string to control when the current target
+loads its dependencies into memory before running.
+(Here, a "dependency" is another target upstream that the current one
+depends on.) Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's dependencies are loaded on the host machine
 and sent to the worker before the target runs.
-\item \code{"worker"}: the worker loads the targets dependencies.
-\item \code{"none"}: the dependencies are not loaded at all.
-This choice is almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language.
+\item \code{"worker"}: the worker loads the target's dependencies.
+\item \code{"none"}: \code{targets} makes no attempt to load its
+dependencies. With \code{retrieval = "none"}, loading dependencies
+is the responsibility of the user. Use with caution.
 }}
 
 \item{cue}{An optional object from \code{tar_cue()} to customize the
@@ -216,6 +222,11 @@ be iterated over using dynamic branching.
 \note{
 The \code{iteration} argument is unavailable because it is hard-coded to
 \code{"list"}, the only option that works currently.
+
+When using the \code{\link[=tile_blocksize]{tile_blocksize()}} helper function, you may need to set
+\code{memory = "transient"} on the upstream target provided to the \code{raster}
+argument of \code{tar_terra_tiles()}.  More details are in the help file for
+\code{\link[=tile_blocksize]{tile_blocksize()}}.
 }
 \examples{
 if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {

--- a/man/tar_terra_vect.Rd
+++ b/man/tar_terra_vect.Rd
@@ -90,7 +90,9 @@ stops and throws an error. Options:
 \item \code{"continue"}: the whole pipeline keeps going.
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
-up to date for the next run of the pipeline.
+up to date for the next run of the pipeline. In addition,
+as of version 1.8.0.9011, a value of \code{NULL} is given
+to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
 \item \code{"trim"}: all currently running targets stay running. A queued
@@ -109,19 +111,26 @@ to begin running.
 to learn how to debug targets using saved workspaces.)
 }}
 
-\item{memory}{Character of length 1, memory strategy.
-If \code{"persistent"}, the target stays in memory
+\item{memory}{Character of length 1, memory strategy. Possible values:
+\itemize{
+\item \code{"auto"}: new in \code{targets} version 1.8.0.9011, \code{memory = "auto"}
+is equivalent to \code{memory = "transient"} for dynamic branching
+(a non-null \code{pattern} argument) and \code{memory = "persistent"}
+for targets that do not use dynamic branching.
+\item \code{"persistent"}: the target stays in memory
 until the end of the pipeline (unless \code{storage} is \code{"worker"},
 in which case \code{targets} unloads the value from memory
 right after storing it in order to avoid sending
 copious data over a network).
-If \code{"transient"}, the target gets unloaded
+\item \code{"transient"}: the target gets unloaded
 after every new target completes.
 Either way, the target gets automatically loaded into memory
 whenever another target needs the value.
+}
+
 For cloud-based dynamic files
 (e.g. \code{format = "file"} with \code{repository = "aws"}),
-this memory strategy applies to the
+the \code{memory} option applies to the
 temporary local copy of the file:
 \code{"persistent"} means it remains until the end of the pipeline
 and is then deleted,
@@ -129,8 +138,17 @@ and \code{"transient"} means it gets deleted as soon as possible.
 The former conserves bandwidth,
 and the latter conserves local storage.}
 
-\item{garbage_collection}{Logical, whether to run \code{base::gc()}
-just before the target runs.}
+\item{garbage_collection}{Logical: \code{TRUE} to run \code{base::gc()}
+just before the target runs,
+\code{FALSE} to omit garbage collection.
+In the case of high-performance computing,
+\code{gc()} runs both locally and on the parallel worker.
+All this garbage collection is skipped if the actual target
+is skipped in the pipeline.
+Non-logical values of \code{garbage_collection} are converted to \code{TRUE} or
+\code{FALSE} using \code{isTRUE()}. In other words, non-logical values are
+converted \code{FALSE}. For example, \code{garbage_collection = 2}
+is equivalent to \code{garbage_collection = FALSE}.}
 
 \item{deployment}{Character of length 1. If \code{deployment} is
 \code{"main"}, then the target will run on the central controlling R process.
@@ -151,47 +169,33 @@ functionality, alternative data storage formats,
 and other optional capabilities of \code{targets}.
 See \code{tar_resources()} for details.}
 
-\item{storage}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{storage}{Character string to control when the output of the target
+is saved to storage. Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's return value is sent back to the
 host machine and saved/uploaded locally.
 \item \code{"worker"}: the worker saves/uploads the value.
-\item \code{"none"}: almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language. If you do use it,
-then the return value of the target is totally ignored
-when the target ends, but
-each downstream target still attempts to load the data file
-(except when \code{retrieval = "none"}).
-
-If you select \code{storage = "none"}, then
-the return value of the target's command is ignored,
-and the data is not saved automatically.
-As with dynamic files (\code{format = "file"}) it is the
-responsibility of the user to write to
-the data store from inside the target.
-
-The distinguishing feature of \code{storage = "none"}
-(as opposed to \code{format = "file"})
-is that in the general case,
-downstream targets will automatically try to load the data
-from the data store as a dependency. As a corollary, \code{storage = "none"}
-is completely unnecessary if \code{format} is \code{"file"}.
+\item \code{"none"}: \code{targets} makes no attempt to save the result
+of the target to storage in the location where \code{targets}
+expects it to be. Saving to storage is the responsibility
+of the user. Use with caution.
 }}
 
-\item{retrieval}{Character of length 1, only relevant to
-\code{\link[targets:tar_make_clustermq]{tar_make_clustermq()}} and \code{\link[targets:tar_make_future]{tar_make_future()}}.
+\item{retrieval}{Character string to control when the current target
+loads its dependencies into memory before running.
+(Here, a "dependency" is another target upstream that the current one
+depends on.) Only relevant when using \code{targets}
+with parallel workers (\url{https://books.ropensci.org/targets/crew.html}).
 Must be one of the following values:
 \itemize{
 \item \code{"main"}: the target's dependencies are loaded on the host machine
 and sent to the worker before the target runs.
-\item \code{"worker"}: the worker loads the targets dependencies.
-\item \code{"none"}: the dependencies are not loaded at all.
-This choice is almost never recommended. It is only for
-niche situations, e.g. the data needs to be loaded
-explicitly from another language.
+\item \code{"worker"}: the worker loads the target's dependencies.
+\item \code{"none"}: \code{targets} makes no attempt to load its
+dependencies. With \code{retrieval = "none"}, loading dependencies
+is the responsibility of the user. Use with caution.
 }}
 
 \item{cue}{An optional object from \code{tar_cue()} to customize the

--- a/man/tile_helpers.Rd
+++ b/man/tile_helpers.Rd
@@ -19,9 +19,11 @@ tile_n(raster, n)
 
 \item{nrow}{integer; number of rows to split the SpatRaster into.}
 
-\item{n_blocks_row}{integer; multiple of blocksize to include in each tile vertically.}
+\item{n_blocks_row}{integer; multiple of blocksize to include in each tile
+vertically.}
 
-\item{n_blocks_col}{integer; multiple of blocksize to include in each tile horizontally.}
+\item{n_blocks_col}{integer; multiple of blocksize to include in each tile
+horizontally.}
 
 \item{n}{integer; total number of tiles to split the SpatRaster into.}
 }
@@ -36,14 +38,22 @@ While these may have general use, they are intended primarily for supplying
 to the \code{tile_fun} argument of \code{\link[=tar_terra_tiles]{tar_terra_tiles()}}.
 }
 \details{
-\code{tile_blocksize()} creates extents using the raster's native blocksize (see
+\code{tile_blocksize()} creates extents using the raster's native block size (see
 \code{\link[terra:readwrite]{terra::fileBlocksize()}}), which should be more memory efficient. Create
 tiles with multiples of the raster's blocksize with \code{n_blocks_row} and
 \code{n_blocks_col}. We strongly suggest the user explore how many tiles are
 created by \code{tile_blocksize()} before creating a dynamically branched target
-using this helper. \code{tile_grid()} allows specification of a number of rows and
+using this helper. Note that block size is a property of \emph{files} and does not
+apply to in-memory \code{SpatRaster}s. Therefore, if you want to use this helper
+in \code{\link[=tar_terra_tiles]{tar_terra_tiles()}} you may need to ensure the upstream target provided to
+the \code{raster} argument is not in memory by setting \code{memory = "transient"}.
+
+\code{tile_grid()} allows specification of a number of rows and
 columns to split the raster into.  E.g. nrow = 2 and ncol = 2 would create 4
 tiles (because it specifies a 2x2 matrix, which has 4 elements).
+
+\code{tile_n()} creates (about) \code{n} tiles and prints the number of rows, columns,
+and total tiles created.
 }
 \examples{
 f <- system.file("ex/elev.tif", package="terra")


### PR DESCRIPTION
Add documentation to `tar_terra_tiles()` and `tile_blocksize()` explaining why and how to force upstream targets to not be in memory.

Also updates other documentation because of running `document()` with `targets` 1.9.0 installed