### PR TITLE
handle check() notes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests:
     ncmeta,
     sf,
     stars,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    fs
 Config/testthat/edition: 3
 URL: https://github.com/njtierney/geotargets, https://njtierney.github.io/geotargets/
 BugReports: https://github.com/njtierney/geotargets/issues

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -62,6 +62,7 @@ tar_stars <- function(name,
                       description = targets::tar_option_get("description")) {
 
     check_pkg_installed("stars")
+    if (ncdf) check_pkg_installed("ncmeta")
 
     name <- targets::tar_deparse_language(substitute(name))
 
@@ -130,6 +131,7 @@ tar_stars_proxy <- function(name,
                             description = targets::tar_option_get("description")) {
 
     check_pkg_installed("stars")
+    if (ncdf) check_pkg_installed("ncmeta")
 
     name <- targets::tar_deparse_language(substitute(name))
 
@@ -218,7 +220,6 @@ tar_stars_raw <- function(name,
         format = targets::tar_format(
             read = function(path) {
                 if (ncdf) {
-                    geotargets:::check_pkg_installed("ncmeta")
                     stars::read_ncdf(path, proxy = proxy)
                 } else if (isTRUE(mdim)) {
                     stars::read_mdim(path, proxy = proxy)

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -62,7 +62,9 @@ tar_stars <- function(name,
                       description = targets::tar_option_get("description")) {
 
     check_pkg_installed("stars")
-    if (ncdf) check_pkg_installed("ncmeta")
+    if (ncdf) {
+        check_pkg_installed("ncmeta")
+    }
 
     name <- targets::tar_deparse_language(substitute(name))
 
@@ -131,7 +133,9 @@ tar_stars_proxy <- function(name,
                             description = targets::tar_option_get("description")) {
 
     check_pkg_installed("stars")
-    if (ncdf) check_pkg_installed("ncmeta")
+    if (ncdf) {
+        check_pkg_installed("ncmeta")
+    }
 
     name <- targets::tar_deparse_language(substitute(name))
 


### PR DESCRIPTION
Deals with two `check()` notes:

- adds `fs` to Suggests (it is used in vignette)
- moves `geotargets:::check_pkg_installed()` outside of a write function so it can just be `check_pkg_installed()`