### PR TITLE
Fix missing data when `preserve_metadata = "zip"`

### DIFF
--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -137,7 +137,10 @@ tar_terra_rast <- function(name,
 tar_rast_read <- function(preserve_metadata) {
   switch(preserve_metadata,
     zip = function(path) {
-      tmp <- withr::local_tempdir()
+      tmp <- tempdir()
+      # NOTE: cannot use withr::local_tempdir() because the unzipped files need
+      # to persist so that the resulting `SpatRaster` object doesn't have a
+      # broken file pointer
       zip::unzip(zipfile = path, exdir = tmp)
       terra::rast(file.path(tmp, basename(path)))
     },

--- a/tests/testthat/test-tar-terra-rast.R
+++ b/tests/testthat/test-tar-terra-rast.R
@@ -143,11 +143,13 @@ tar_test("metadata is maintained", {
       r
     }
     list(
-      tar_terra_rast(r, make_rast())
+      tar_terra_rast(r, make_rast()),
+      tar_terra_rast(r2, make_rast(), preserve_metadata = "drop")
     )
   })
   tar_make()
   x <- tar_read(r)
   expect_equal(terra::units(x), rep("m", 3))
   expect_equal(terra::time(x), as.Date("2024-10-01") + c(0, 1, 2))
+  expect_equal(head(terra::values(x)), head(terra::values(tar_read(r2))))
 })


### PR DESCRIPTION
In my quest to preserve metadata in raster targets I accidentally forgot to preserve the **data**.  We can't use `withr::local_tempdir()` in the read function because it'll get cleaned up and the resulting `SpatRaster` will have a broken file pointer.  I don't love this solution, but the only other workaround I can think of is to force the `SpatRaster` to point to memory (e.g. by adding 0 or multiplying by 1 after reading), and I like that solution less I think.

Fixes #127.