### PR TITLE
Some improvements for metadata being preserved.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     targets (>= 1.8.0),
     rlang (>= 1.1.3),
     cli (>= 3.6.2),
-    terra (>= 1.7.71),
+    terra (>= 1.8-10),
     withr (>= 3.0.0),
     zip,
     lifecycle

--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -27,7 +27,13 @@
 #'   not include layer names set with `names() <-`).  When `"zip"`, these
 #'   metadata are retained by archiving all written files as a zip file upon
 #'   writing and unzipping them upon reading. This adds extra overhead and will
-#'   slow pipelines.
+#'   slow pipelines. Also note metadata may be impacted by different versions
+#'   of GDAL and different drivers. If you have an issue with retaining
+#'   metadata for your setup, please file an issue at
+#'   \url{https://github.com/njtierney/geotargets/issues/} and we will try and
+#'   get this working for you. Also note that you can specify this option for
+#'   individual targets, e.g., inside [tar_terra_rast()] there is the option
+#'   `preserve_metadata`.
 #'
 #' @details
 #' These options can also be set using `options()`.  For example,

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -22,13 +22,20 @@
 #'   to [terra::writeRaster()]
 #' @param gdal character. GDAL driver specific datasource creation options
 #'   passed to [terra::writeRaster()]
-#' @param preserve_metadata character. When `"drop"` (default), any auxiliary
-#'   files that would be written by [terra::writeRaster()] containing raster
-#'   metadata such as units and datetimes are lost (note that this does not
-#'   include layer names set with `names() <-`).  When `"zip"`, these metadata
-#'   are retained by archiving all written files as a zip file upon writing and
-#'   unzipping them upon reading. This adds extra overhead and will slow
-#'   pipelines.
+#' @param preserve_metadata character. When `"drop"` (default), any
+#'   auxiliary files that would be written by [terra::writeRaster()] containing
+#'   raster metadata such as units and datetimes are lost (note that this does
+#'   not include layer names set with `names() <-`).  When `"zip"`, these
+#'   metadata are retained by archiving all written files as a zip file upon
+#'   writing and unzipping them upon reading. This adds extra overhead and will
+#'   slow pipelines. Also note metadata may be impacted by different versions
+#'   of GDAL and different drivers. If you have an issue with retaining
+#'   metadata for your setup, please file an issue at
+#'   \url{https://github.com/njtierney/geotargets/issues/} and we will try and
+#'   get this working for you. Also note that you can specify this option
+#'   inside [geotargets_option_set()] if you want to set this for the entire
+#'   pipeline.
+#'
 #' @param ... Additional arguments not yet used
 #'
 #' @inheritParams targets::tar_target

--- a/man/geotargets-options.Rd
+++ b/man/geotargets-options.Rd
@@ -44,7 +44,13 @@ raster metadata such as units and datetimes are lost (note that this does
 not include layer names set with \verb{names() <-}).  When \code{"zip"}, these
 metadata are retained by archiving all written files as a zip file upon
 writing and unzipping them upon reading. This adds extra overhead and will
-slow pipelines.}
+slow pipelines. Also note metadata may be impacted by different versions
+of GDAL and different drivers. If you have an issue with retaining
+metadata for your setup, please file an issue at
+\url{https://github.com/njtierney/geotargets/issues/} and we will try and
+get this working for you. Also note that you can specify this option for
+individual targets, e.g., inside \code{\link[=tar_terra_rast]{tar_terra_rast()}} there is the option
+\code{preserve_metadata}.}
 
 \item{name}{character; option name to get.}
 }

--- a/man/tar_terra_rast.Rd
+++ b/man/tar_terra_rast.Rd
@@ -44,13 +44,19 @@ to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
 \item{gdal}{character. GDAL driver specific datasource creation options
 passed to \code{\link[terra:writeRaster]{terra::writeRaster()}}}
 
-\item{preserve_metadata}{character. When \code{"drop"} (default), any auxiliary
-files that would be written by \code{\link[terra:writeRaster]{terra::writeRaster()}} containing raster
-metadata such as units and datetimes are lost (note that this does not
-include layer names set with \verb{names() <-}).  When \code{"zip"}, these metadata
-are retained by archiving all written files as a zip file upon writing and
-unzipping them upon reading. This adds extra overhead and will slow
-pipelines.}
+\item{preserve_metadata}{character. When \code{"drop"} (default), any
+auxiliary files that would be written by \code{\link[terra:writeRaster]{terra::writeRaster()}} containing
+raster metadata such as units and datetimes are lost (note that this does
+not include layer names set with \verb{names() <-}).  When \code{"zip"}, these
+metadata are retained by archiving all written files as a zip file upon
+writing and unzipping them upon reading. This adds extra overhead and will
+slow pipelines. Also note metadata may be impacted by different versions
+of GDAL and different drivers. If you have an issue with retaining
+metadata for your setup, please file an issue at
+\url{https://github.com/njtierney/geotargets/issues/} and we will try and
+get this working for you. Also note that you can specify this option
+inside \code{\link[=geotargets_option_set]{geotargets_option_set()}} if you want to set this for the entire
+pipeline.}
 
 \item{...}{Additional arguments not yet used}
 

--- a/tests/testthat/test-tar-terra-rast.R
+++ b/tests/testthat/test-tar-terra-rast.R
@@ -128,12 +128,44 @@ tar_test("That changing filetype invalidates a target", {
   expect_equal(tar_outdated(), "r")
 })
 
-tar_test("metadata is maintained", {
+tar_test("metadata is maintained for GTiff", {
   tar_script({
     library(targets)
     library(geotargets)
     library(terra)
-    geotargets_option_set(terra_preserve_metadata = "zip")
+    geotargets_option_set(
+        terra_preserve_metadata = "zip",
+        gdal_raster_driver = "GTiff" # default
+        )
+    make_rast <- function() {
+      f <- system.file("ex/elev.tif", package = "terra")
+      r <- terra::rast(f)
+      r <- c(r, r + 10, r / 2)
+      terra::units(r) <- rep("m", 3)
+      terra::time(r) <- as.Date("2024-10-01") + c(0, 1, 2)
+      r
+    }
+    list(
+      tar_terra_rast(r, make_rast()),
+      tar_terra_rast(r2, make_rast(), preserve_metadata = "drop")
+    )
+  })
+  tar_make()
+  x <- tar_read(r)
+  expect_equal(terra::units(x), rep("m", 3))
+  expect_equal(terra::time(x), as.Date("2024-10-01") + c(0, 1, 2))
+  expect_equal(head(terra::values(x)), head(terra::values(tar_read(r2))))
+})
+
+tar_test("metadata is maintained for COG", {
+  tar_script({
+    library(targets)
+    library(geotargets)
+    library(terra)
+    geotargets_option_set(
+        terra_preserve_metadata = "zip",
+        gdal_raster_driver = "COG"
+        )
     make_rast <- function() {
       f <- system.file("ex/elev.tif", package = "terra")
       r <- terra::rast(f)


### PR DESCRIPTION
- Update to latest version of terra (1.8-10) to ensure metadata is saved for raster drivers like COG.
- Add documentation that details that some versions GDAL and raster drivers might not save metadata and to contact us if there's an issue
- Add test to ensure metadata is maintained for GTiff and COG
- resolves #146